### PR TITLE
Extract index from the high hash bits instead of the low bits.

### DIFF
--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -23,10 +23,10 @@ fn map_serde_tokens() {
             Token::Map { len: Some(3) },
             Token::Char('a'),
             Token::I32(10),
-            Token::Char('b'),
-            Token::I32(20),
             Token::Char('c'),
             Token::I32(30),
+            Token::Char('b'),
+            Token::I32(20),
             Token::MapEnd,
         ],
     );
@@ -50,9 +50,9 @@ fn set_serde_tokens() {
         &set,
         &[
             Token::Seq { len: Some(3) },
-            Token::I32(20),
             Token::I32(10),
             Token::I32(30),
+            Token::I32(20),
             Token::SeqEnd,
         ],
     );

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -13,20 +13,14 @@ fn map_serde_tokens_empty() {
 #[test]
 fn map_serde_tokens() {
     let mut map = HashMap::new();
-    map.insert('b', 20);
     map.insert('a', 10);
-    map.insert('c', 30);
 
     assert_tokens(
         &map,
         &[
-            Token::Map { len: Some(3) },
+            Token::Map { len: Some(1) },
             Token::Char('a'),
             Token::I32(10),
-            Token::Char('c'),
-            Token::I32(30),
-            Token::Char('b'),
-            Token::I32(20),
             Token::MapEnd,
         ],
     );
@@ -42,17 +36,13 @@ fn set_serde_tokens_empty() {
 #[test]
 fn set_serde_tokens() {
     let mut set = HashSet::new();
-    set.insert(20);
     set.insert(10);
-    set.insert(30);
 
     assert_tokens(
         &set,
         &[
-            Token::Seq { len: Some(3) },
+            Token::Seq { len: Some(1) },
             Token::I32(10),
-            Token::I32(30),
-            Token::I32(20),
             Token::SeqEnd,
         ],
     );


### PR DESCRIPTION
Some Hashers, and FxHasher in particular, mix the low bits poorly; so only use the high bits for both hashes.

Instead of introducing bucket_shift next to bucket_mask in the top-level struct, derive them both from capacity_log2. This avoids exacerbating struct size in #69.

This change is also a prerequisite for rayon-based parallel collect, which requires that the high bits of the index are always in the same place regardless of table size.

 name                     old ns/iter  new ns/iter  diff ns/iter   diff %  speedup
 find_existing            0            0                       0     NaN%    x NaN
 find_existing_high_bits  84,320       3,442             -80,878  -95.92%  x 24.50
 find_nonexisting         0            0                       0     NaN%    x NaN
 get_remove_insert        25           29                      4   16.00%   x 0.86
 grow_by_insertion        205          209                     4    1.95%   x 0.98
 grow_by_insertion_kb     290          180                  -110  -37.93%   x 1.61
 hashmap_as_queue         25           26                      1    4.00%   x 0.96
 insert_8_char_string     18,038       17,491               -547   -3.03%   x 1.03
 new_drop                 0            0                       0     NaN%    x NaN
 new_insert_drop          45           50                      5   11.11%   x 0.90