### PR TITLE
Replace benchmarks with (slightly) better ones

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,7 +3,7 @@
 extern crate test;
 
 use std::hash::Hash;
-use test::Bencher;
+use test::{black_box, Bencher};
 
 use hashbrown::HashMap;
 //use rustc_hash::FxHashMap as HashMap;
@@ -14,146 +14,137 @@ fn new_map<K: Eq + Hash, V>() -> HashMap<K, V> {
 }
 
 #[bench]
-fn new_drop(b: &mut Bencher) {
+fn insert_i32(b: &mut Bencher) {
     b.iter(|| {
-        let m: HashMap<i32, i32> = new_map();
-        assert_eq!(m.len(), 0);
+        let mut m: HashMap<i32, i32> = new_map();
+        for i in 1..1001 {
+            m.insert(i, i);
+        }
+        black_box(m);
     })
 }
 
 #[bench]
-fn new_insert_drop(b: &mut Bencher) {
+fn insert_i64(b: &mut Bencher) {
     b.iter(|| {
-        let mut m = new_map();
-        m.insert(0, 0);
-        assert_eq!(m.len(), 1);
+        let mut m: HashMap<i64, i64> = new_map();
+        for i in 1..1001 {
+            m.insert(i, i);
+        }
+        black_box(m);
     })
 }
 
 #[bench]
-fn grow_by_insertion(b: &mut Bencher) {
-    let mut m = new_map();
-
-    for i in 1..1001 {
-        m.insert(i, i);
-    }
-
-    let mut k = 1001;
-
+fn insert_erase_i32(b: &mut Bencher) {
     b.iter(|| {
-        m.insert(k, k);
-        k += 1;
-    });
+        let mut m: HashMap<i32, i32> = new_map();
+        for i in 1..1001 {
+            m.insert(i, i);
+        }
+        black_box(&mut m);
+        for i in 1..1001 {
+            m.remove(&i);
+        }
+        black_box(m);
+    })
 }
 
 #[bench]
-fn grow_by_insertion_kb(b: &mut Bencher) {
-    let mut m = new_map();
-    let kb = 1024;
-    for i in 1..1001 {
-        m.insert(i * kb, i);
-    }
-
-    let mut k = 1001 * kb;
-
+fn insert_erase_i64(b: &mut Bencher) {
     b.iter(|| {
-        m.insert(k, k);
-        k += kb;
-    });
+        let mut m: HashMap<i64, i64> = new_map();
+        for i in 1..1001 {
+            m.insert(i, i);
+        }
+        black_box(&mut m);
+        for i in 1..1001 {
+            m.remove(&i);
+        }
+        black_box(m);
+    })
 }
 
 #[bench]
-fn find_existing(b: &mut Bencher) {
-    let mut m = new_map();
-
+fn lookup_i32(b: &mut Bencher) {
+    let mut m: HashMap<i32, i32> = new_map();
     for i in 1..1001 {
         m.insert(i, i);
     }
 
     b.iter(|| {
         for i in 1..1001 {
-            m.contains_key(&i);
+            black_box(m.get(&i));
         }
-    });
+    })
 }
 
 #[bench]
-fn find_existing_high_bits(b: &mut Bencher) {
-    let mut m = new_map();
-
-    for i in 1..1001_u64 {
-        m.insert(i << 32, i);
+fn lookup_i64(b: &mut Bencher) {
+    let mut m: HashMap<i64, i64> = new_map();
+    for i in 1..1001 {
+        m.insert(i, i);
     }
 
     b.iter(|| {
-        for i in 1..1001_u64 {
-            m.contains_key(&(i << 32));
+        for i in 1..1001 {
+            black_box(m.get(&i));
         }
-    });
+    })
 }
 
 #[bench]
-fn find_nonexisting(b: &mut Bencher) {
-    let mut m = new_map();
-
+fn lookup_fail_i32(b: &mut Bencher) {
+    let mut m: HashMap<i32, i32> = new_map();
     for i in 1..1001 {
         m.insert(i, i);
     }
 
     b.iter(|| {
         for i in 1001..2001 {
-            m.contains_key(&i);
+            black_box(m.get(&i));
         }
-    });
-}
-
-#[bench]
-fn hashmap_as_queue(b: &mut Bencher) {
-    let mut m = new_map();
-
-    for i in 1..1001 {
-        m.insert(i, i);
-    }
-
-    let mut k = 1;
-
-    b.iter(|| {
-        m.remove(&k);
-        m.insert(k + 1000, k + 1000);
-        k += 1;
-    });
-}
-
-#[bench]
-fn get_remove_insert(b: &mut Bencher) {
-    let mut m = new_map();
-
-    for i in 1..1001 {
-        m.insert(i, i);
-    }
-
-    let mut k = 1;
-
-    b.iter(|| {
-        m.get(&(k + 400));
-        m.get(&(k + 2000));
-        m.remove(&k);
-        m.insert(k + 1000, k + 1000);
-        k += 1;
     })
 }
 
 #[bench]
-fn insert_8_char_string(b: &mut Bencher) {
-    let mut strings: Vec<_> = Vec::new();
+fn lookup_fail_i64(b: &mut Bencher) {
+    let mut m: HashMap<i64, i64> = new_map();
     for i in 1..1001 {
-        strings.push(format!("{:x}", -i));
+        m.insert(i, i);
     }
 
-    let mut m = new_map();
     b.iter(|| {
-        for key in &strings {
-            m.insert(key, key);
+        for i in 1001..2001 {
+            black_box(m.get(&i));
+        }
+    })
+}
+
+#[bench]
+fn iter_i32(b: &mut Bencher) {
+    let mut m: HashMap<i32, i32> = new_map();
+    for i in 1..1001 {
+        m.insert(i, i);
+    }
+
+    b.iter(|| {
+        for i in &m {
+            black_box(i);
+        }
+    })
+}
+
+#[bench]
+fn iter_i64(b: &mut Bencher) {
+    let mut m: HashMap<i64, i64> = new_map();
+    for i in 1..1001 {
+        m.insert(i, i);
+    }
+
+    b.iter(|| {
+        for i in &m {
+            black_box(i);
         }
     })
 }


### PR DESCRIPTION
While not as extensive as [Google's hashtable benchmarks](https://github.com/google/hashtable-benchmarks), this should at least help make sure we don't unintentionally regress performance.