### PR TITLE
Use unaligned load/stores.

### DIFF
--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -47,24 +47,11 @@ impl Group {
         Group(x86::_mm_loadu_si128(ptr as *const _))
     }
 
-    /// Loads a group of bytes starting at the given address, which must be
-    /// aligned to `mem::align_of::<Group>()`.
+    /// Stores the group of bytes to the given address.
     #[inline]
-    #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn load_aligned(ptr: *const u8) -> Self {
-        // FIXME: use align_offset once it stabilizes
-        debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        Group(x86::_mm_load_si128(ptr as *const _))
-    }
-
-    /// Stores the group of bytes to the given address, which must be
-    /// aligned to `mem::align_of::<Group>()`.
-    #[inline]
-    #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn store_aligned(self, ptr: *mut u8) {
-        // FIXME: use align_offset once it stabilizes
-        debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        x86::_mm_store_si128(ptr as *mut _, self.0);
+    #[allow(clippy::cast_ptr_alignment)] // unaligned load
+    pub unsafe fn store(self, ptr: *const u8) {
+        x86::_mm_storeu_si128(ptr as *mut _, self.0)
     }
 
     /// Returns a `BitMask` indicating all bytes in the group which have


### PR DESCRIPTION
There is no penalty for unaligned load/stores on x86 post Nehalem.