### PR TITLE
Proof of Concept: Outlined RawTable

### DIFF
--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -53,22 +53,6 @@ impl Group {
     /// Number of bytes in the group.
     pub const WIDTH: usize = mem::size_of::<Self>();
 
-    /// Returns a full group of empty bytes, suitable for use as the initial
-    /// value for an empty hash table.
-    ///
-    /// This is guaranteed to be aligned to the group size.
-    #[inline]
-    pub fn static_empty() -> &'static [u8] {
-        union AlignedBytes {
-            _align: Group,
-            bytes: [u8; Group::WIDTH],
-        };
-        const ALIGNED_BYTES: AlignedBytes = AlignedBytes {
-            bytes: [EMPTY; Group::WIDTH],
-        };
-        unsafe { &ALIGNED_BYTES.bytes }
-    }
-
     /// Loads a group of bytes starting at the given address.
     #[inline]
     #[allow(clippy::cast_ptr_alignment)] // unaligned load

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -19,26 +19,10 @@ pub const BITMASK_MASK: BitMaskWord = 0xffff;
 pub struct Group(x86::__m128i);
 
 // FIXME: https://github.com/rust-lang/rust-clippy/issues/3859
-#[allow(clippy::use_self)] 
+#[allow(clippy::use_self)]
 impl Group {
     /// Number of bytes in the group.
     pub const WIDTH: usize = mem::size_of::<Self>();
-
-    /// Returns a full group of empty bytes, suitable for use as the initial
-    /// value for an empty hash table.
-    ///
-    /// This is guaranteed to be aligned to the group size.
-    #[inline]
-    pub fn static_empty() -> &'static [u8] {
-        union AlignedBytes {
-            _align: Group,
-            bytes: [u8; Group::WIDTH],
-        };
-        const ALIGNED_BYTES: AlignedBytes = AlignedBytes {
-            bytes: [EMPTY; Group::WIDTH],
-        };
-        unsafe { &ALIGNED_BYTES.bytes }
-    }
 
     /// Loads a group of bytes starting at the given address.
     #[inline]


### PR DESCRIPTION
Needs some cleanup, but here's the basic implementation of what I suggested in #69 

Doesn't seem to have been that hard since we already were set up for singleton shenanigans and RawTable is actually a fairly small file.

This reduces `size_of::<hashbrown::HashMap>()` to 8, and `size_of::<std::HashMap>()` to 24 on 64-bit platforms (only difference is SipHash random seed). However it does strictly increase the overall memory footprint of the map by 8, since there is now an additional pointer-to-the-header. This can potentially be avoided (see notes below).

Some quick notes in random order:

* the ctrl and data ptrs had to be changed to raw pointers, as NonNull cannot be constructed in a `const` context
* consequently, I also had to make them `*const` to get the right variance
* the `Sync` impl for Header is so it can be put in a static
* `is_empty_singleton` changed to a pointer comparison to a static value, which should be faster than looking up the len
* added a ton of getters for convenience, should presumably evaporate in opt
* I believe it is always safe to access all the header fields immutably, as even new_uninitialized initializes those fields immediately.
* We avoid any dependency on the size or align of T with the singleton header because its only reference to T is an always-aligned null pointer to T.
* Group::empty_singleton() is removed, as it was duplicate code and also it needs to be inline in the static singleton's expr. Also ALIGNED_BYTES is changed to a static so that it is guaranteed to have stable pointer identity (miri was upset about this).
* I adjusted calculate_layout to only align the data array to `T` instead of `max(T, Group)`. It's unclear to me why the implementation was doing that, except that I guess it let that statically-computed value be reused for the `alloc` call. I also just refactored that code to be clearer since it was getting a bit hairy with 3 components.

Potential Optimization Worth Considering: `ctrl` *should* have a statically-known offset from `header`. As such it's possible we can remove the `ctrl` pointer and just compute it on demand?

I have not yet benchmarked this at all. Not sure what tools we have for this outside of me just running `cargo bench` locally.