### PR TITLE
skip Miri tests if the setup fails

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -5,7 +5,6 @@ set -ex
 export CARGO_NET_RETRY=5
 export CARGO_NET_TIMEOUT=10
 
-if rustup component add miri ; then
-    cargo miri setup
+if rustup component add miri && cargo miri setup ; then
     cargo miri test -- -- -Zunstable-options --exclude-should-panic
 fi


### PR DESCRIPTION
Currently we are in a situation where Miri can be installed but `cargo miri setup` fails (due to https://github.com/rust-lang/miri/issues/713).  That should not lead to hashbrown's CI failing.

Cc @gnzlbg 