### PR TITLE
cast the entire slice to a raw pointer, not just the first element

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -357,7 +357,8 @@ impl<T> RawTable<T> {
     pub fn new() -> Self {
         Self {
             data: NonNull::dangling(),
-            ctrl: NonNull::from(&Group::static_empty()[0]),
+            // Be careful to cast the entire slice to a raw pointer.
+            ctrl: unsafe { NonNull::new_unchecked(Group::static_empty().as_ptr() as *mut u8) },
             bucket_mask: 0,
             items: 0,
             growth_left: 0,


### PR DESCRIPTION
A strict reading of pointer provenance implies that when a `&T` gets cast to `*const T`, you may only use the raw pointer to access that `T`, not its neighbors.  That's what Miri currently implements, though it is less strict around statics (which is why this one does not currently cause a Miri failure -- I'd like to make Miri more strict though).

Cc https://github.com/rust-lang/unsafe-code-guidelines/issues/134