### PR TITLE
Expose the Layout of the failed allocation in CollectionAllocErr::AllocErr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashbrown"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "A Rust port of Google's SwissTable hash map"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ pub enum CollectionAllocErr {
     /// Error due to the computed capacity exceeding the collection's maximum
     /// (usually `isize::MAX` bytes).
     CapacityOverflow,
-    /// Error due to the allocator (see the `AllocErr` type's docs).
-    AllocErr,
+    /// Error due to the allocator.
+    AllocErr {
+        /// The layout of the allocation request that failed.
+        layout: alloc::alloc::Layout,
+    },
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3402,12 +3402,12 @@ mod test_map {
             panic!("usize::MAX should trigger an overflow!");
         }
 
-        if let Err(AllocErr) = empty_bytes.try_reserve(MAX_USIZE / 8) {
+        if let Err(AllocErr { .. }) = empty_bytes.try_reserve(MAX_USIZE / 8) {
         } else {
             // This may succeed if there is enough free memory. Attempt to
             // allocate a second hashmap to ensure the allocation will fail.
             let mut empty_bytes2: HashMap<u8, u8> = HashMap::new();
-            if let Err(AllocErr) = empty_bytes2.try_reserve(MAX_USIZE / 8) {
+            if let Err(AllocErr { .. }) = empty_bytes2.try_reserve(MAX_USIZE / 8) {
             } else {
                 panic!("usize::MAX / 8 should trigger an OOM!");
             }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -83,7 +83,7 @@ impl Fallibility {
     #[inline]
     fn alloc_err(self, layout: Layout) -> CollectionAllocErr {
         match self {
-            Fallibility::Fallible => CollectionAllocErr::AllocErr,
+            Fallibility::Fallible => CollectionAllocErr::AllocErr { layout },
             Fallibility::Infallible => handle_alloc_error(layout),
         }
     }


### PR DESCRIPTION
This a breaking change to a public API.

This enables a similar change proposed in `std`: https://github.com/rust-lang/rust/issues/48043#issuecomment-500828346

There is precedent for this in the `hashglobe` crate, which is Firefox’s (pre-hashbrown) fork of `std::collections::HashMap` with stable `try_reserve`.

* https://github.com/servo/servo/blob/b3eed5b5bd/components/hashglobe/src/lib.rs#L29-L42
* https://github.com/servo/servo/blob/b3eed5b5bd/components/hashglobe/src/hash_map.rs#L722