### PR TITLE
Fix rust syntax highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ hashbrown = "0.5"
 
 Then:
 
-```rs
+```rust
 use hashbrown::HashMap;
 let mut map = HashMap::new();
 ```


### PR DESCRIPTION
This PR extends #87 a tiny bit and enables the syntax highlighting of the rust code block. The original code identifier `rs` is not recognised by the renderer in github; changing it to `rust` fixes this.

Before:
<img width="265" alt="Screenshot 2019-06-13 at 22 29 53" src="https://user-images.githubusercontent.com/302566/59468792-ded85180-8e2a-11e9-98e7-0543fd90b35b.png">
After:
<img width="254" alt="Screenshot 2019-06-13 at 22 30 05" src="https://user-images.githubusercontent.com/302566/59468803-e4359c00-8e2a-11e9-8e52-e0518319c13d.png">
