### PR TITLE
Fix E0658 due to alloc feature being unstable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(
     feature = "nightly",
     feature(
+        alloc,
         alloc_layout_extra,
         allocator_api,
         ptr_offset_from,


### PR DESCRIPTION
Fixes

```
error[E0658]: use of unstable library feature 'alloc': this library is
unlikely to be stabilized in its current form or name (see issue #27783)
  -->
/Users/$USER/.cargo/registry/src/github.com-1ecc6299db9ec823/hashbrown-0.5.0/src/lib.rs:34:1
   |
34 | extern crate alloc;
   | ^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(alloc)] to the crate attributes to enable

```