### PR TITLE
miri CI: use latest nightly with Miri

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -5,6 +5,11 @@ set -ex
 export CARGO_NET_RETRY=5
 export CARGO_NET_TIMEOUT=10
 
-if rustup component add miri && cargo miri setup ; then
-    cargo miri test -- -- -Zunstable-options --exclude-should-panic
-fi
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+cargo miri test -- -- -Zunstable-options --exclude-should-panic


### PR DESCRIPTION
Instead of giving up when the latest nightly has no Miri, install the latest nightly that does have Miri.