### PR TITLE
Add manual Send and Sync impls for RawOccupiedEntryMut

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1280,6 +1280,19 @@ pub struct RawOccupiedEntryMut<'a, K, V> {
     table: &'a mut RawTable<(K, V)>,
 }
 
+unsafe impl<K, V> Send for RawOccupiedEntryMut<'_, K, V>
+where
+    K: Send,
+    V: Send,
+{
+}
+unsafe impl<K, V> Sync for RawOccupiedEntryMut<'_, K, V>
+where
+    K: Sync,
+    V: Sync,
+{
+}
+
 /// A view into a vacant entry in a `HashMap`.
 /// It is part of the [`RawEntryMut`] enum.
 ///


### PR DESCRIPTION
These impls match the raw impls for `OccupiedEntry`, which are necessary because
they both contain `Bucket` which is not automatically `Sync`.

I believe `RawOccupiedEntryMut` is already automatically `Send`, but this adds
both manual impls to match `OccupiedEntry`.

Fixes #99 