### PR TITLE
Add new 'rustc-internal-api' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,5 @@ serde_test = "1.0"
 [features]
 default = []
 nightly = []
-rustc-dep-of-std = ["nightly", "core", "compiler_builtins", "alloc"]
+rustc-internal-api = []
+rustc-dep-of-std = ["nightly", "core", "compiler_builtins", "alloc", "rustc-internal-api"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod external_trait_impls;
 mod fx;
 mod map;
 mod raw;
-#[cfg(feature = "rustc-dep-of-std")]
+#[cfg(feature = "rustc-internal-api")]
 mod rustc_entry;
 mod scopeguard;
 mod set;
@@ -51,7 +51,7 @@ pub mod hash_map {
     //! A hash map implemented with quadratic probing and SIMD lookup.
     pub use crate::map::*;
 
-    #[cfg(feature = "rustc-dep-of-std")]
+    #[cfg(feature = "rustc-internal-api")]
     pub use crate::rustc_entry::*;
 
     #[cfg(feature = "rayon")]


### PR DESCRIPTION
The new 'rustc-internal-api' controls access to the exported internal
API used by rustc. This is fully backwards compatible, as
'rustc-dep-of-std' depends on 'rustc-internal-api'

This supports https://github.com/rust-lang/rust/pull/62513