### PR TITLE
Add doc-comment to check README file code examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.5.1"
 rayon = "1.0"
 rustc-hash = "1.0"
 serde_test = "1.0"
+doc-comment = "0.3.1"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The original C++ version of SwissTable can be found [here], and this
 
 Compared to `std::collections::HashMap`:
 
-```
+```text
  name               stdhash ns/iter  hashbrown ns/iter  diff ns/iter    diff %  speedup
  find_existing      23,831           2,935                   -20,896   -87.68%   x 8.12
  find_nonexisting   25,326           2,283                   -23,043   -90.99%  x 11.09
@@ -45,7 +45,7 @@ Compared to `std::collections::HashMap`:
 
 Compared to `rustc_hash::FxHashMap` (standard `HashMap` using `FxHash` instead of `SipHash`):
 
-```
+```text
  name               fxhash ns/iter  hashbrown ns/iter  diff ns/iter    diff %  speedup
  find_existing      5,951           2,935                    -3,016   -50.68%   x 2.03
  find_nonexisting   4,637           2,283                    -2,354   -50.77%   x 2.03
@@ -69,7 +69,9 @@ Then:
 
 ```rust
 use hashbrown::HashMap;
+
 let mut map = HashMap::new();
+map.insert(1, "one");
 ```
 
 This crate has the following Cargo features:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@
         ptr_offset_from,
         test,
         core_intrinsics,
-        dropck_eyepatch
+        dropck_eyepatch,
+        cfg_doctest,
     )
 )]
 #![warn(missing_docs)]
@@ -34,6 +35,10 @@ extern crate std;
 extern crate alloc;
 #[cfg(not(has_extern_crate_alloc))]
 extern crate std as alloc;
+
+#[cfg(feature = "nightly")]
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Considering that there is actually only one example, don't hesitate to close it if you find it not worth it.