### PR TITLE
Group::static_empty() change const to static.

### DIFF
--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -63,7 +63,7 @@ impl Group {
             _align: Group,
             bytes: [u8; Group::WIDTH],
         };
-        const ALIGNED_BYTES: AlignedBytes = AlignedBytes {
+        static ALIGNED_BYTES: AlignedBytes = AlignedBytes {
             bytes: [EMPTY; Group::WIDTH],
         };
         unsafe { &ALIGNED_BYTES.bytes }

--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -54,7 +54,8 @@ impl Group {
     pub const WIDTH: usize = mem::size_of::<Self>();
 
     /// Returns a full group of empty bytes, suitable for use as the initial
-    /// value for an empty hash table.
+    /// value for an empty hash table. This value is explicitly declared as
+    /// a static variable to ensure the address is consistent across dylibs.
     ///
     /// This is guaranteed to be aligned to the group size.
     #[inline]

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -19,7 +19,7 @@ pub const BITMASK_MASK: BitMaskWord = 0xffff;
 pub struct Group(x86::__m128i);
 
 // FIXME: https://github.com/rust-lang/rust-clippy/issues/3859
-#[allow(clippy::use_self)] 
+#[allow(clippy::use_self)]
 impl Group {
     /// Number of bytes in the group.
     pub const WIDTH: usize = mem::size_of::<Self>();
@@ -34,7 +34,7 @@ impl Group {
             _align: Group,
             bytes: [u8; Group::WIDTH],
         };
-        const ALIGNED_BYTES: AlignedBytes = AlignedBytes {
+        static ALIGNED_BYTES: AlignedBytes = AlignedBytes {
             bytes: [EMPTY; Group::WIDTH],
         };
         unsafe { &ALIGNED_BYTES.bytes }

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -25,7 +25,8 @@ impl Group {
     pub const WIDTH: usize = mem::size_of::<Self>();
 
     /// Returns a full group of empty bytes, suitable for use as the initial
-    /// value for an empty hash table.
+    /// value for an empty hash table. This value is explicitly declared as
+    /// a static variable to ensure the address is consistent across dylibs.
     ///
     /// This is guaranteed to be aligned to the group size.
     #[inline]


### PR DESCRIPTION
Fixes #115.