### PR TITLE
Add RustcVacantEntry::insert_entry for rust-lang/rust#64656

### DIFF
--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -546,6 +546,32 @@ impl<'a, K, V> RustcVacantEntry<'a, K, V> {
         let bucket = self.table.insert_no_grow(self.hash, (self.key, value));
         unsafe { &mut bucket.as_mut().1 }
     }
+
+    /// Sets the value of the entry with the RustcVacantEntry's key,
+    /// and returns a RustcOccupiedEntry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::RustcEntry;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// if let RustcEntry::Vacant(v) = map.rustc_entry("poneyland") {
+    ///     let o = v.insert_entry(37);
+    ///     assert_eq!(o.get(), &37);
+    /// }
+    /// ```
+    #[inline]
+    pub fn insert_entry(self, value: V) -> RustcOccupiedEntry<'a, K, V> {
+        let bucket = self.table.insert_no_grow(self.hash, (self.key, value));
+        RustcOccupiedEntry {
+            key: None,
+            elem: bucket,
+            table: self.table,
+        }
+    }
 }
 
 impl<K, V> IterMut<'_, K, V> {

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -125,6 +125,28 @@ impl<K: Debug, V> Debug for RustcVacantEntry<'_, K, V> {
 }
 
 impl<'a, K, V> RustcEntry<'a, K, V> {
+    /// Sets the value of the entry, and returns a RustcOccupiedEntry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    /// let entry = map.entry("horseyland").insert(37);
+    ///
+    /// assert_eq!(entry.key(), &"horseyland");
+    /// ```
+    pub fn insert(self, value: V) -> RustcOccupiedEntry<'a, K, V> {
+        match self {
+            Vacant(entry) => entry.insert_entry(value),
+            Occupied(mut entry) => {
+                entry.insert(value);
+                entry
+            }
+        }
+    }
+
     /// Ensures a value is in the entry by inserting the default if empty, and returns
     /// a mutable reference to the value in the entry.
     ///


### PR DESCRIPTION
See rust-lang/rust#64656.

~~This was based on v0.5.0 as that's what rustc uses; I can rebase onto master, but I'm not sure whether rustc wants v0.6.0 or if v0.6.0 is rustc-ready.~~

For context, this ultimately provides an API with this shape:

```rust
impl Entry<'a, K, V> {
    fn insert(self, value: V) -> OccupiedEntry<'a, K, V> {…}
}
```

to be used when one wants to insert a value without consuming the Entry, e.g. because one wants to keep a reference to the key around. There's more at the original (defunct) PR: rust-lang/rust#60142.