### PR TITLE
Introduce `ahash-compile-time-rng` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.2.11", optional = true }
+ahash = { version = "0.2.11", optional = true, default-features = false }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }
@@ -37,7 +37,13 @@ serde_test = "1.0"
 doc-comment = "0.3.1"
 
 [features]
-default = ["ahash", "inline-more"]
+default = [
+    "ahash",
+    "ahash-compile-time-rng",
+    "inline-more",
+]
+
+ahash-compile-time-rng = [ "ahash/compile-time-rng" ]
 nightly = []
 rustc-internal-api = []
 rustc-dep-of-std = ["nightly", "core", "compiler_builtins", "alloc", "rustc-internal-api"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ This crate has the following Cargo features:
 - `raw`: Enables access to the experimental and unsafe `RawTable` API.
 - `inline-more`: Adds inline hints to most functions, improving run-time performance at the cost
   of compilation time. (enabled by default)
+- `ahash`: Compiles with ahash as default hasher. (enabled by default)
+- `ahash-compile-time-rng`: Activates the `compile-time-rng` feature of ahash, to increase the
+   DOS-resistance, but can result in issues for `no_std` builds. More details in
+   [issue#124](https://github.com/rust-lang/hashbrown/issues/124). (enabled by default)
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,12 @@
         cfg_doctest,
     )
 )]
+#![allow(
+    clippy::doc_markdown,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate
+)]
 #![warn(missing_docs)]
-#![allow(clippy::module_name_repetitions, clippy::doc_markdown)]
 #![warn(rust_2018_idioms)]
 
 #[cfg(test)]


### PR DESCRIPTION
**Content**

Disables the default features of `ahash` and reintroduces them
through a new feature called `ahash-compile-time-rng`, which is
enabled by default.

The new feature makes it possible for depended crates to rely on
`hashbrown` with `ahash` as default hasher and to disable the
`compile-time-rng` at the same time.

This might be useful for any depended crate targeting `no_std`,
which contains `rand` or `rand_core` somewhere inside the dependency
tree as a bug in cargo accidentally enables the underlying `getrandom`
feature if `compile-time-rng` is enabled [1].

... fixes #124

[1] https://github.com/rust-lang/cargo/issues/5760

---

**Warnings**

 (1) Compiling `ahash` with disabled `compile-time-rng` feature is currently broken and requires https://github.com/tkaitchuck/aHash/pull/25 to be merged in advance.

 (2) This introduces a hidden behavior change for all dependent crates, using hashbrown with `default-features = false` and `features = 'ahash'`. This happens as the `ahash` feature no longer implicitly enables the `compile-time-rng` feature of `ahash`.

---

Is the naming of the feature okay?  Do I need to add any additional  changes?