### PR TITLE
Remove i686-apple-darwin from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,6 @@ matrix:
       env: TARGET=x86_64-apple-darwin
       os: osx
       osx_image: xcode10
-    - name: "i686-apple-darwin"
-      env: TARGET=i686-apple-darwin
-      os: osx
-      osx_image: xcode10
     - name: "x86_64-pc-windows-msvc"
       env: TARGET=x86_64-pc-windows-msvc
       os: windows


### PR DESCRIPTION
This target is [no longer supported by rustup](https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html).