### PR TITLE
Make HaspMap and RawTable to be repr(C)

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -190,6 +190,7 @@ pub enum DefaultHashBuilder {}
 ///     // use the values stored in map
 /// }
 /// ```
+#[repr(C)]
 #[derive(Clone)]
 pub struct HashMap<K, V, S = DefaultHashBuilder> {
     pub(crate) hash_builder: S,

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -329,6 +329,7 @@ impl<T> Bucket<T> {
 }
 
 /// A raw hash table with an unsafe API.
+#[repr(C)]
 pub struct RawTable<T> {
     // Mask to get an index from a hash value. The value is one less than the
     // number of buckets in the table.


### PR DESCRIPTION
Adding `repr(C)` isn't expected to change anything, since the `RawTable` consists purely of pointers and pointer-sized integers. It will, however, make it possible to pass hashmaps across the FFI boundary, which would be useful to Gecko-integrated Rust projects, such as `wgpu`.
cc @Gankra