### PR TITLE
Upgrade ahash and rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ autocfg = "1"
 
 [dev-dependencies]
 lazy_static = "1.2"
-rand = "0.5.1"
+rand = { version = "0.7.3", features = ["small_rng"] }
 rayon = "1.0"
 rustc-hash = "1.0"
 serde_test = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashbrown"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "A Rust port of Google's SwissTable hash map"
 license = "Apache-2.0/MIT"
@@ -14,7 +14,7 @@ build = "build.rs"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.2.11", optional = true, default-features = false }
+ahash = { version = "0.3.2", optional = true, default-features = false }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use core::ops::Index;
 
 /// Default hasher for `HashMap`.
 #[cfg(feature = "ahash")]
-pub type DefaultHashBuilder = ahash::ABuildHasher;
+pub type DefaultHashBuilder = ahash::RandomState;
 
 /// Dummy default hasher for `HashMap`.
 #[cfg(not(feature = "ahash"))]

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -1,7 +1,7 @@
 #![cfg(not(miri))] // FIXME: takes too long
 
 use hashbrown::HashSet;
-use rand::{distributions::Alphanumeric, Rng, SeedableRng, XorShiftRng};
+use rand::{distributions::Alphanumeric, rngs::SmallRng, Rng, SeedableRng};
 
 #[test]
 fn test_hashset_insert_remove() {
@@ -12,8 +12,7 @@ fn test_hashset_insert_remove() {
         130, 220, 246, 217, 111, 124, 221, 189, 190, 234, 121, 93, 67, 95, 100, 43,
     ];
 
-    let mut rng: XorShiftRng = SeedableRng::from_seed(seed);
-    //let mut rng: XorShiftRng = XorShiftRng::new_unseeded();
+    let rng = &mut SmallRng::from_seed(seed);
     let tx: Vec<Vec<char>> = (0..4096)
         .map(|_| (rng.sample_iter(&Alphanumeric).take(32).collect()))
         .collect();


### PR DESCRIPTION
This upgrades ahash to 0.3.2 and (dev) rand to 0.7.3. This is a breaking change because ahash is a public dependency for its hasher type, so I also took the liberty of bumping to hashbrown 0.7.0.