### PR TITLE
Disable use of const_random! by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ doc-comment = "0.3.1"
 [features]
 default = [
     "ahash",
-    "ahash-compile-time-rng",
     "inline-more",
 ]
 


### PR DESCRIPTION
It unfortunately makes reproducible builds impossible.