### PR TITLE
Another attempt to reduce size_of<HashMap>

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -434,6 +434,7 @@ impl<T> RawTable<T> {
 
     /// Returns pointer to start of data table.
     #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(dead_code)]
     pub unsafe fn compute_data_ptr(&self) -> *mut T {
         self.data_backwards().as_ptr().sub(self.buckets())
     }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -232,7 +232,7 @@ fn calculate_layout<T>(buckets: usize) -> Option<(Layout, usize)> {
     let ctrl = unsafe { Layout::from_size_align_unchecked(buckets + Group::WIDTH, Group::WIDTH) };
 
     // There must be no padding between two tables.
-    debug_assert_eq!(padded_data.padding_needed_for(Group::WIDTH), 0);
+    debug_assert_eq!(data.padding_needed_for(Group::WIDTH), 0);
 
     data.extend(ctrl).ok()
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -215,7 +215,7 @@ fn bucket_mask_to_capacity(bucket_mask: usize) -> usize {
 /// Returns `None` if an overflow occurs.
 #[cfg_attr(feature = "inline-more", inline)]
 #[cfg(feature = "nightly")]
-pub fn calculate_layout<T>(buckets: usize) -> Option<(Layout, usize)> {
+fn calculate_layout<T>(buckets: usize) -> Option<(Layout, usize)> {
     debug_assert!(buckets.is_power_of_two());
 
     let common_align = usize::max(mem::align_of::<T>(), Group::WIDTH);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -269,7 +269,7 @@ impl<T> Bucket<T> {
         } else {
             // the pointer arithmetic below might cross allocation bounds
             // because RawTable::iter() could call this function with empty table and index=0
-            base.as_ptr().wrapping_offset(!index as isize)
+            base.as_ptr().wrapping_add(!index) as usize as *mut T
         };
         Self {
             ptr: NonNull::new_unchecked(ptr),

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -434,8 +434,8 @@ impl<T> RawTable<T> {
 
     /// Returns pointer to start of data table.
     #[cfg_attr(feature = "inline-more", inline)]
-    pub unsafe fn compute_data_ptr(&self) -> NonNull<T> {
-        NonNull::new_unchecked(self.data_backwards().as_ptr().sub(self.buckets()))
+    pub unsafe fn compute_data_ptr(&self) -> *mut T {
+        self.data_backwards().as_ptr().sub(self.buckets())
     }
 
     /// Returns the index of a bucket from a `Bucket`.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -231,9 +231,6 @@ fn calculate_layout<T>(buckets: usize) -> Option<(Layout, usize)> {
     // Group::WIDTH is a small number.
     let ctrl = unsafe { Layout::from_size_align_unchecked(buckets + Group::WIDTH, Group::WIDTH) };
 
-    // There must be no padding between two tables.
-    debug_assert_eq!(data.padding_needed_for(Group::WIDTH), 0);
-
     data.extend(ctrl).ok()
 }
 


### PR DESCRIPTION
##### Changes made
- `data` field is removed, instead the allocation layout is changed such that first element of control bytes start exactly at one past last element of bucket table. So we just use negative index to access bucket table without touching size field. Allocation layout looks like this: https://github.com/rust-lang/hashbrown/blob/7027781128a4896aea0aebd4f3f6590b8776dea9/src/raw/mod.rs#L359-L361
- Changed `calculate_layout` implementation:
  - Layout is now `[Paddings] | [Buckets] | [Ctrls]`, previously it was `[Ctrls] | [Paddings] | [Buckets]`
  - Returned offset is now start of control bytes in the allocation and also one past last element of buckets. (Previously it was data offset)
- Renamed `Bucket::add` to `Bucket::next_n`

##### Drawbacks
- Development cost? accessing with negative index seems awkward
- Code is slower on cases where start of data pointer is needed

##### Issues
- calling `Bucket::as_ptr()` on one past last element yields UB (crosses allocation boundary).
- `data_start()` doesn't equal `data_end()` when table is empty because empty table returns buckets() == 1

cargo benchcmp (from local)
```
 name                         before ns/iter  after ns/iter  diff ns/iter   diff %  speedup 
 clone_from_large             1,454           1,858                   404   27.79%   x 0.78 
 clone_from_small             17              22                        5   29.41%   x 0.77 
 clone_large                  1,985           1,731                  -254  -12.80%   x 1.15 
 clone_small                  47              39                       -8  -17.02%   x 1.21 
 insert_ahash_highbits        9,314           8,935                  -379   -4.07%   x 1.04 
 insert_ahash_random          9,556           9,509                   -47   -0.49%   x 1.00 
 insert_ahash_serial          9,739           9,475                  -264   -2.71%   x 1.03 
 insert_erase_ahash_highbits  20,957          20,920                  -37   -0.18%   x 1.00 
 insert_erase_ahash_random    21,220          22,805                1,585    7.47%   x 0.93 
 insert_erase_ahash_serial    25,188          24,349                 -839   -3.33%   x 1.03 
 insert_erase_std_highbits    50,005          50,587                  582    1.16%   x 0.99 
 insert_erase_std_random      49,894          50,796                  902    1.81%   x 0.98 
 insert_erase_std_serial      42,161          44,495                2,334    5.54%   x 0.95 
 insert_std_highbits          22,460          22,433                  -27   -0.12%   x 1.00 
 insert_std_random            22,554          22,943                  389    1.72%   x 0.98 
 insert_std_serial            19,504          19,748                  244    1.25%   x 0.99 
 iter_ahash_highbits          1,659           1,747                    88    5.30%   x 0.95 
 iter_ahash_random            1,626           1,743                   117    7.20%   x 0.93 
 iter_ahash_serial            1,492           1,520                    28    1.88%   x 0.98 
 iter_std_highbits            1,639           1,792                   153    9.33%   x 0.91 
 iter_std_random              1,600           1,834                   234   14.62%   x 0.87 
 iter_std_serial              1,466           1,500                    34    2.32%   x 0.98 
 lookup_ahash_highbits        4,445           4,912                   467   10.51%   x 0.90 
 lookup_ahash_random          4,467           4,964                   497   11.13%   x 0.90 
 lookup_ahash_serial          6,240           4,738                -1,502  -24.07%   x 1.32 
 lookup_fail_ahash_highbits   4,241           4,444                   203    4.79%   x 0.95 
 lookup_fail_ahash_random     4,514           4,603                    89    1.97%   x 0.98 
 lookup_fail_ahash_serial     4,471           4,622                   151    3.38%   x 0.97 
 lookup_fail_std_highbits     18,394          18,476                   82    0.45%   x 1.00 
 lookup_fail_std_random       18,129          18,378                  249    1.37%   x 0.99 
 lookup_fail_std_serial       15,348          15,716                  368    2.40%   x 0.98 
 lookup_std_highbits          18,042          18,351                  309    1.71%   x 0.98 
 lookup_std_random            18,247          18,567                  320    1.75%   x 0.98 
 lookup_std_serial            15,054          15,767                  713    4.74%   x 0.95 
```

Some of results vary a lot in my tests, they seem roughly same except `clone_from_large` is slower.
