### PR TITLE
impl Clone for RawIntoIter, and add table access methods

### DIFF
--- a/src/external_trait_impls/rayon/raw.rs
+++ b/src/external_trait_impls/rayon/raw.rs
@@ -1,5 +1,5 @@
 use crate::raw::Bucket;
-use crate::raw::{RawIterRange, RawTable};
+use crate::raw::{RawIter, RawIterRange, RawTable};
 use crate::scopeguard::guard;
 use alloc::alloc::dealloc;
 use core::marker::PhantomData;
@@ -13,6 +13,12 @@ use rayon::iter::{
 /// Parallel iterator which returns a raw pointer to every full bucket in the table.
 pub struct RawParIter<T> {
     iter: RawIterRange<T>,
+}
+
+impl<T> From<RawIter<T>> for RawParIter<T> {
+    fn from(it: RawIter<T>) -> Self {
+        RawParIter { iter: it.iter }
+    }
 }
 
 impl<T> ParallelIterator for RawParIter<T> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -3284,13 +3284,13 @@ mod test_map {
             let mut it2 = it1.clone();
             assert_eq!(it1.len(), n);
             assert_eq!(it2.len(), n);
-            for _ in 0..n {
+            for i in 0..n {
                 let e1 = it1.next();
                 let (k, v) = e1.unwrap();
 
-                let mut hasher = hasher.build_hasher();
-                k.hash(&mut hasher);
-                let hash = hasher.finish();
+                let mut hsh = hasher.build_hasher();
+                k.hash(&mut hsh);
+                let hash = hsh.finish();
 
                 // since we have yielded the item from it1, it should no longer "have" (k, v)
                 let e1 = crate::raw::RawIntoIter::find(&it1, hash, |q| q.0.eq(&k));
@@ -3306,6 +3306,26 @@ mod test_map {
                 // and now the same find should fail
                 let e2 = crate::raw::RawIntoIter::find(&it2, hash, |q| q.0.eq(&k));
                 assert_eq!(e2.map(|b| unsafe { b.as_ref() }), None);
+
+                // check that all the finds work out the way they should
+                let mut hits = 0;
+                for j in 0..n {
+                    let mut hsh = hasher.build_hasher();
+                    j.hash(&mut hsh);
+                    let hash = hsh.finish();
+
+                    let e1 = crate::raw::RawIntoIter::find(&it1, hash, |q| q.0.eq(&j));
+                    let e2 = crate::raw::RawIntoIter::find(&it2, hash, |q| q.0.eq(&j));
+                    if e1.is_some() {
+                        hits += 1;
+                    }
+                    assert_eq!(
+                        e1.map(|b| unsafe { b.as_ref() }),
+                        e2.map(|b| unsafe { b.as_ref() })
+                    );
+                }
+                // we should hit for all the keys we haven't iterated over yet
+                assert_eq!(hits, n - i - 1);
             }
             assert_eq!(it1.next(), None);
             assert_eq!(it2.next(), None);
@@ -3367,9 +3387,9 @@ mod test_map {
                 }
                 let (k, v) = e1.unwrap();
 
-                let mut hasher = hasher.build_hasher();
-                k.hash(&mut hasher);
-                let hash = hasher.finish();
+                let mut hsh = hasher.build_hasher();
+                k.hash(&mut hsh);
+                let hash = hsh.finish();
 
                 // since we have yielded the item from it1, it should no longer "have" (k, v)
                 let e1 = crate::raw::RawIntoIter::find(&it1, hash, |q| q.0.eq(&k));
@@ -3385,6 +3405,26 @@ mod test_map {
                 // and now the same find should fail
                 let e2 = crate::raw::RawIntoIter::find(&it2, hash, |q| q.0.eq(&k));
                 assert_eq!(e2.map(|b| unsafe { b.as_ref() }), None);
+
+                // check that all the finds work out the way they should
+                let mut hits = 0;
+                for j in 0..n {
+                    let mut hsh = hasher.build_hasher();
+                    j.hash(&mut hsh);
+                    let hash = hsh.finish();
+
+                    let e1 = crate::raw::RawIntoIter::find(&it1, hash, |q| q.0.eq(&j));
+                    let e2 = crate::raw::RawIntoIter::find(&it2, hash, |q| q.0.eq(&j));
+                    if e1.is_some() {
+                        hits += 1;
+                    }
+                    assert_eq!(
+                        e1.map(|b| unsafe { b.as_ref() }),
+                        e2.map(|b| unsafe { b.as_ref() })
+                    );
+                }
+                // we should hit for all the keys we haven't iterated over yet
+                assert_eq!(hits, left - i - 1);
 
                 i += 1;
             }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3187,6 +3187,23 @@ mod test_map {
     }
 
     #[test]
+    fn test_into_iter_clone_independent() {
+        let mut m = HashMap::new();
+        let n = 1024;
+        for i in 0..n {
+            assert!(m.insert(i, std::boxed::Box::new(2 * i)).is_none());
+        }
+        let it1 = m.table.into_iter();
+        let it2 = it1.clone();
+        for (_, mut e) in it1 {
+            *e = usize::max_value();
+        }
+        for (k, v) in it2 {
+            assert_eq!(*v, 2 * k);
+        }
+    }
+
+    #[test]
     #[cfg(feature = "raw")]
     fn test_into_iter_find_with_remove() {
         use core::hash::{BuildHasher, Hash, Hasher};

--- a/src/map.rs
+++ b/src/map.rs
@@ -3222,7 +3222,7 @@ mod test_map {
                     unsafe {
                         let e = crate::raw::RawIntoIter::find(&it, hash, |q| q.0.eq(&i));
                         if let Some(e) = e {
-                            crate::raw::RawIntoIter::erase_no_drop(&mut it, &e);
+                            crate::raw::RawIntoIter::erase(&mut it, e);
                             left -= 1;
                         }
                     }
@@ -3367,8 +3367,8 @@ mod test_map {
                         let e2 = crate::raw::RawIntoIter::find(&it2, hash, |q| q.0.eq(&i));
                         assert_eq!(e1.is_some(), e2.is_some());
                         if let (Some(e1), Some(e2)) = (e1, e2) {
-                            crate::raw::RawIntoIter::erase_no_drop(&mut it1, &e1);
-                            crate::raw::RawIntoIter::erase_no_drop(&mut it2, &e2);
+                            crate::raw::RawIntoIter::erase(&mut it1, e1);
+                            crate::raw::RawIntoIter::erase(&mut it2, e2);
                             left -= 1;
                         }
                     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3102,7 +3102,10 @@ mod test_map {
         assert_eq!(m.iter_mut().next(), None);
         assert_eq!(m.len(), 0);
         assert!(m.is_empty());
-        assert_eq!(m.into_iter().next(), None);
+        let mut it = m.into_iter();
+        let mut it2 = it.inner.clone();
+        assert_eq!(it.next(), None);
+        assert_eq!(it2.next(), None);
     }
 
     #[test]
@@ -3167,6 +3170,45 @@ mod test_map {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_empty_into_iter_clone() {
+        let m: HashMap<i32, i32> = HashMap::new();
+        let it = m.table.into_iter();
+        let it2 = it.clone();
+        assert_eq!(it.count(), it2.count());
+    }
+
+    #[test]
+    fn test_into_iter_clone_eq() {
+        let mut m = HashMap::new();
+        let n = 1024;
+        for i in 0..n {
+            assert!(m.insert(i, 2 * i).is_none());
+        }
+        let it1 = m.table.into_iter();
+        let it2 = it1.clone();
+        assert_eq!(it1.len(), n);
+        assert_eq!(it1.len(), it2.len());
+        for (e1, e2) in it1.zip(it2) {
+            assert_eq!(e1, e2);
+        }
+    }
+
+    #[test]
+    fn test_into_iter_clone() {
+        let mut m = HashMap::new();
+        let n = 1024;
+        for i in 0..n {
+            assert!(m.insert(i, 2 * i).is_none());
+        }
+        let it = m.table.into_iter();
+        let it2 = it.clone();
+        drop(it);
+        let mut it = it2;
+        assert_eq!(it.len(), 1024);
+        assert!(it.all(|(k, v)| v == 2 * k));
     }
 
     #[test]

--- a/src/map.rs
+++ b/src/map.rs
@@ -3281,10 +3281,11 @@ mod test_map {
             let hasher = m.hasher().clone();
 
             let mut it1 = m.table.into_iter();
-            let mut it2 = it1.clone();
             assert_eq!(it1.len(), n);
-            assert_eq!(it2.len(), n);
             for i in 0..n {
+                let mut it2 = it1.clone();
+                assert_eq!(it2.len(), it1.len());
+
                 let e1 = it1.next();
                 let (k, v) = e1.unwrap();
 
@@ -3328,6 +3329,7 @@ mod test_map {
                 assert_eq!(hits, n - i - 1);
             }
             assert_eq!(it1.next(), None);
+            let mut it2 = it1.clone();
             assert_eq!(it2.next(), None);
 
             // and just as a sanity check, all finds should fail now
@@ -3356,13 +3358,14 @@ mod test_map {
             let hasher = m.hasher().clone();
 
             let mut it1 = m.table.into_iter();
-            let mut it2 = it1.clone();
             assert_eq!(it1.len(), n);
-            assert_eq!(it2.len(), n);
 
             let mut i = 0;
             let mut left = n;
             loop {
+                let mut it2 = it1.clone();
+                assert_eq!(it2.len(), it1.len());
+
                 // occasionally remove some elements
                 if i % 3 == 0 {
                     let mut hasher = hasher.build_hasher();
@@ -3430,6 +3433,7 @@ mod test_map {
             }
             assert_eq!(i, left);
             assert_eq!(it1.next(), None);
+            let mut it2 = it1.clone();
             assert_eq!(it2.next(), None);
 
             // and just as a sanity check, all finds should fail now

--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -25,6 +25,14 @@ impl BitMask {
         BitMask(self.0 ^ BITMASK_MASK)
     }
 
+    /// Returns a new `BitMask` that is ANDed with the given mask.
+    #[inline]
+    #[must_use]
+    #[cfg(feature = "raw")]
+    pub fn and(self, other: BitMask) -> Self {
+        BitMask(self.0 & other.0)
+    }
+
     /// Returns a new `BitMask` with the lowest bit removed.
     #[inline]
     #[must_use]

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1474,7 +1474,7 @@ impl<T: Clone> Clone for RawIntoIter<T> {
                 // lookups.
                 self.table
                     .ctrl(0)
-                    .copy_to_nonoverlapping(table.ctrl(0), table.num_ctrl_bytes());
+                    .copy_to_nonoverlapping(table.ctrl(0), self.table.num_ctrl_bytes());
 
                 // Next, we move over all the _remaining_ non-empty buckets.
                 // We can do so without knowing the hash since the tables are identical.
@@ -1518,7 +1518,7 @@ impl<T: Clone> Clone for RawIntoIter<T> {
 
                     // next_ctrl is at the same offset to end
                     next_ctrl: if next_ctrl > end {
-                        iter.iter.iter.end
+                        iter.iter.iter.end.add(next_ctrl as usize - end as usize)
                     } else {
                         iter.iter.iter.end.sub(end as usize - next_ctrl as usize)
                     },

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1567,6 +1567,7 @@ unsafe impl<#[may_dangle] T> Drop for RawIntoIter<T> {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }
+                self.table.clear_no_drop();
             }
 
             // Free the table
@@ -1584,6 +1585,7 @@ impl<T> Drop for RawIntoIter<T> {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }
+                self.table.clear_no_drop();
             }
 
             // Free the table

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1497,11 +1497,10 @@ impl<T: Clone> Clone for RawIntoIter<T> {
                     data: iter.table.bucket(self.table.bucket_index(data)),
 
                     // next_ctrl is at the same offset to end
-                    // next_ctrl increases towards end, so it is normally smaller than end
                     next_ctrl: if next_ctrl > end {
                         iter.iter.iter.end
                     } else {
-                        iter.iter.iter.end.add(end.sub(next_ctrl as usize) as usize)
+                        iter.iter.iter.end.add(end as usize - next_ctrl as usize)
                     },
 
                     // The updated end is the one to use.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1500,7 +1500,7 @@ impl<T: Clone> Clone for RawIntoIter<T> {
                     next_ctrl: if next_ctrl > end {
                         iter.iter.iter.end
                     } else {
-                        iter.iter.iter.end.add(end as usize - next_ctrl as usize)
+                        iter.iter.iter.end.sub(end as usize - next_ctrl as usize)
                     },
 
                     // The updated end is the one to use.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1569,9 +1569,7 @@ unsafe impl<#[may_dangle] T> Drop for RawIntoIter<T> {
             }
 
             // Free the table
-            if let Some((ptr, layout)) = ManuallyDrop::take(&mut self.table).into_alloc() {
-                dealloc(ptr.as_ptr(), layout);
-            }
+            ManuallyDrop::drop(&mut self.table)
         }
     }
 }
@@ -1588,9 +1586,7 @@ impl<T> Drop for RawIntoIter<T> {
             }
 
             // Free the table
-            if let Some((ptr, layout)) = ManuallyDrop::take(&mut self.table).into_alloc() {
-                dealloc(ptr.as_ptr(), layout);
-            }
+            ManuallyDrop::drop(&mut self.table)
         }
     }
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1567,16 +1567,29 @@ impl<T> RawIntoIter<T> {
         self.iter.clone()
     }
 
-    /// Erases an element from the table without dropping it.
+    /// Erases and drops an element from the table.
     #[cfg_attr(feature = "inline-more", inline)]
     #[cfg(feature = "raw")]
-    pub unsafe fn erase_no_drop(&mut self, item: &Bucket<T>) {
-        self.table.erase_no_drop(item);
+    pub unsafe fn erase(&mut self, item: Bucket<T>) {
+        self.table.erase(item);
         // Fix up the iterator so it doesn't yield the erased element.
         // Since there are no items left in the table before the iterator's location,
         // we know that the erased item must have been coming up in the iterator.
         self.iter.items -= 1;
         self.iter.iter.refresh_removals();
+    }
+
+    /// Removes and returns an element from the table.
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[cfg(feature = "raw")]
+    pub unsafe fn remove(&mut self, item: Bucket<T>) -> T {
+        let v = self.table.remove(item);
+        // Fix up the iterator so it doesn't yield the erased element.
+        // Since there are no items left in the table before the iterator's location,
+        // we know that the erased item must have been coming up in the iterator.
+        self.iter.items -= 1;
+        self.iter.iter.refresh_removals();
+        v
     }
 
     /// Searches for an element in the table.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1196,7 +1196,7 @@ unsafe impl<#[may_dangle] T> Drop for RawTable<T> {
     fn drop(&mut self) {
         if !self.is_empty_singleton() {
             unsafe {
-                if mem::needs_drop::<T>() {
+                if mem::needs_drop::<T>() && self.len() != 0 {
                     for item in self.iter() {
                         item.drop();
                     }
@@ -1212,7 +1212,7 @@ impl<T> Drop for RawTable<T> {
     fn drop(&mut self) {
         if !self.is_empty_singleton() {
             unsafe {
-                if mem::needs_drop::<T>() {
+                if mem::needs_drop::<T>() && self.len() != 0 {
                     for item in self.iter() {
                         item.drop();
                     }
@@ -1562,7 +1562,7 @@ unsafe impl<#[may_dangle] T> Drop for RawIntoIter<T> {
     fn drop(&mut self) {
         unsafe {
             // Drop all remaining elements
-            if mem::needs_drop::<T>() {
+            if mem::needs_drop::<T>() && self.iter.len() != 0 {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }
@@ -1579,7 +1579,7 @@ impl<T> Drop for RawIntoIter<T> {
     fn drop(&mut self) {
         unsafe {
             // Drop all remaining elements
-            if mem::needs_drop::<T>() {
+            if mem::needs_drop::<T>() && self.iter.len() != 0 {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }
@@ -1638,7 +1638,7 @@ impl<T> Drop for RawDrain<'_, T> {
     fn drop(&mut self) {
         unsafe {
             // Drop all remaining elements. Note that this may panic.
-            if mem::needs_drop::<T>() {
+            if mem::needs_drop::<T>() && self.iter.len() != 0 {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -925,7 +925,7 @@ impl<T> RawTable<T> {
     }
 
     /// Searches for an element in the table, but only at or beyond the given bucket index.
-    #[inline(always)]
+    #[inline]
     fn find_from_bucket(
         &self,
         hash: u64,

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1478,6 +1478,7 @@ impl<T: Clone> Clone for RawIntoIter<T> {
 
                 // Next, we move over all the _remaining_ non-empty buckets.
                 // We can do so without knowing the hash since the tables are identical.
+                // TODO: we could be smarter about this if T: Copy
                 for bucket_in_self in self.iter.clone() {
                     let index = self.table.bucket_index(&bucket_in_self);
                     let bucket_in_new = table.bucket(index);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1483,7 +1483,7 @@ impl<T: Clone> Clone for RawIntoIter<T> {
                     let bucket_in_new = table.bucket(index);
                     bucket_in_new.write(bucket_in_self.as_ref().clone());
                 }
-                table.growth_left -= self.table.growth_left;
+                table.growth_left = self.table.growth_left;
                 table.items = self.table.items;
 
                 // We can now get a RawIntoIter for the new table.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1511,7 +1511,7 @@ unsafe impl<#[may_dangle] T> Drop for RawIntoIter<T> {
             }
 
             // Free the table
-            if let Some((ptr, layout)) = self.table.into_alloc() {
+            if let Some((ptr, layout)) = ManuallyDrop::take(&mut self.table).into_alloc() {
                 dealloc(ptr.as_ptr(), layout);
             }
         }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -999,6 +999,7 @@ impl<T> RawTable<T> {
     /// Converts the table into a raw allocation. The contents of the table
     /// should be dropped using a `RawIter` before freeing the allocation.
     #[cfg_attr(feature = "inline-more", inline)]
+    #[cfg(feature = "rayon")]
     pub(crate) fn into_alloc(self) -> Option<(NonNull<u8>, Layout)> {
         let alloc = if self.is_empty_singleton() {
             None

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1566,6 +1566,9 @@ unsafe impl<#[may_dangle] T> Drop for RawIntoIter<T> {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }
+            }
+            // Make sure we don't re-try dropping them in RawTable::drop
+            if mem::needs_drop::<T>() && self.table.len() != 0 {
                 self.table.clear_no_drop();
             }
 
@@ -1584,6 +1587,9 @@ impl<T> Drop for RawIntoIter<T> {
                 while let Some(item) = self.iter.next() {
                     item.drop();
                 }
+            }
+            // Make sure we don't re-try dropping them in RawTable::drop
+            if mem::needs_drop::<T>() && self.table.len() != 0 {
                 self.table.clear_no_drop();
             }
 


### PR DESCRIPTION
This adds the ability to find and erase elements in a `RawTable` while
it is being consumed using `RawIntoIter`. This may be useful in contexts
where a `RawTable` is being destructed bit-by-bit, interleaved by user
operations.

Specifically, this is (I think) what I'd need for
https://github.com/jonhoo/griddle/issues/1 and
https://github.com/jonhoo/griddle/issues/2.

Please do double-check my implementation here, as I am not
completely sure I got the corner cases right.