### PR TITLE
Add RawTable::erase and remove

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -511,6 +511,21 @@ impl<T> RawTable<T> {
         self.items -= 1;
     }
 
+    /// Erases an element from the table, dropping it in place.
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub unsafe fn erase(&mut self, item: Bucket<T>) {
+        // Erase the element from the table first since drop might panic.
+        self.erase_no_drop(&item);
+        item.drop();
+    }
+
+    /// Removes an element from the table, returning it.
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub unsafe fn remove(&mut self, item: Bucket<T>) -> T {
+        self.erase_no_drop(&item);
+        item.read()
+    }
+
     /// Returns an iterator for a probe sequence on the table.
     ///
     /// This iterator never terminates, but is guaranteed to visit each bucket

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -513,6 +513,7 @@ impl<T> RawTable<T> {
 
     /// Erases an element from the table, dropping it in place.
     #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::needless_pass_by_value)]
     pub unsafe fn erase(&mut self, item: Bucket<T>) {
         // Erase the element from the table first since drop might panic.
         self.erase_no_drop(&item);
@@ -521,6 +522,7 @@ impl<T> RawTable<T> {
 
     /// Removes an element from the table, returning it.
     #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::needless_pass_by_value)]
     pub unsafe fn remove(&mut self, item: Bucket<T>) -> T {
         self.erase_no_drop(&item);
         item.read()

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -318,10 +318,7 @@ impl<'a, K, V> RustcOccupiedEntry<'a, K, V> {
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove_entry(self) -> (K, V) {
-        unsafe {
-            self.table.erase_no_drop(&self.elem);
-            self.elem.read()
-        }
+        unsafe { self.table.remove(self.elem) }
     }
 
     /// Gets a reference to the value in the entry.


### PR DESCRIPTION
The two main uses of `erase_no_drop` are to then drop it in place or
read it out, which are now provided by `erase` and `remove`.