### PR TITLE
Improve RawIter re-usability

### DIFF
--- a/src/external_trait_impls/rayon/raw.rs
+++ b/src/external_trait_impls/rayon/raw.rs
@@ -1,5 +1,5 @@
 use crate::raw::Bucket;
-use crate::raw::{RawIterRange, RawTable};
+use crate::raw::{RawIter, RawIterRange, RawTable};
 use crate::scopeguard::guard;
 use alloc::alloc::dealloc;
 use core::marker::PhantomData;
@@ -13,6 +13,12 @@ use rayon::iter::{
 /// Parallel iterator which returns a raw pointer to every full bucket in the table.
 pub struct RawParIter<T> {
     iter: RawIterRange<T>,
+}
+
+impl<T> From<RawIter<T>> for RawParIter<T> {
+    fn from(it: RawIter<T>) -> Self {
+        RawParIter { iter: it.iter }
+    }
 }
 
 impl<T> ParallelIterator for RawParIter<T> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -3900,8 +3900,13 @@ mod test_map {
     fn test_into_iter_refresh() {
         use core::hash::{BuildHasher, Hash, Hasher};
 
+        #[cfg(miri)]
+        const N: usize = 32;
+        #[cfg(not(miri))]
+        const N: usize = 128;
+
         let mut rng = rand::thread_rng();
-        for n in 0..128 {
+        for n in 0..N {
             let mut m = HashMap::new();
             for i in 0..n {
                 assert!(m.insert(i, 2 * i).is_none());

--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -25,11 +25,17 @@ impl BitMask {
         BitMask(self.0 ^ BITMASK_MASK)
     }
 
-    /// Unset the bit in the mask for the entry at the given index.
+    /// Flip the bit in the mask for the entry at the given index.
+    ///
+    /// Returns the bit's previous state.
     #[inline]
     #[allow(clippy::cast_ptr_alignment)]
-    pub unsafe fn unset(&mut self, index: usize) {
-        self.0 &= !(1 << (index * BITMASK_STRIDE));
+    #[cfg(feature = "raw")]
+    pub unsafe fn flip(&mut self, index: usize) -> bool {
+        let mask = 1 << (index * BITMASK_STRIDE);
+        self.0 ^= mask;
+        // The bit was set if the bit is now 0.
+        self.0 & mask == 0
     }
 
     /// Returns a new `BitMask` with the lowest bit removed.

--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -25,6 +25,13 @@ impl BitMask {
         BitMask(self.0 ^ BITMASK_MASK)
     }
 
+    /// Unset the bit in the mask for the entry at the given index.
+    #[inline]
+    #[allow(clippy::cast_ptr_alignment)]
+    pub unsafe fn unset(&mut self, index: usize) {
+        self.0 &= !(1 << (index * BITMASK_STRIDE));
+    }
+
     /// Returns a new `BitMask` with the lowest bit removed.
     #[inline]
     #[must_use]

--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -32,7 +32,8 @@ impl BitMask {
     #[allow(clippy::cast_ptr_alignment)]
     #[cfg(feature = "raw")]
     pub unsafe fn flip(&mut self, index: usize) -> bool {
-        let mask = 1 << (index * BITMASK_STRIDE);
+        // NOTE: The + BITMASK_STRIDE - 1 is to set the high bit.
+        let mask = 1 << (index * BITMASK_STRIDE + BITMASK_STRIDE - 1);
         self.0 ^= mask;
         // The bit was set if the bit is now 0.
         self.0 & mask == 0

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1490,7 +1490,6 @@ impl<T> RawIter<T> {
             //    We'll also need ot update the item count accordingly.
             if let Some(index) = self.iter.current_group.lowest_set_bit() {
                 let next_bucket = self.iter.data.next_n(index);
-                use core::cmp::Ordering;
                 if b.as_ptr() > next_bucket.as_ptr() {
                     // The toggled bucket is "before" the bucket the iterator would yield next. We
                     // therefore don't need to do anything --- the iterator has already passed the

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1002,9 +1002,11 @@ impl<T> RawTable<T> {
     }
 
     /// Returns an iterator which removes all elements from the table without
-    /// freeing the memory. It is up to the caller to ensure that the `RawTable`
-    /// outlives the `RawDrain`. Because we cannot make the `next` method unsafe
-    /// on the `RawDrain`, we have to make the `drain` method unsafe.
+    /// freeing the memory.
+    ///
+    /// It is up to the caller to ensure that the `RawTable` outlives the `RawDrain`.
+    /// Because we cannot make the `next` method unsafe on the `RawDrain`,
+    /// we have to make the `drain` method unsafe.
     #[cfg_attr(feature = "inline-more", inline)]
     pub unsafe fn drain(&mut self) -> RawDrain<'_, T> {
         let iter = self.iter();
@@ -1012,13 +1014,14 @@ impl<T> RawTable<T> {
     }
 
     /// Returns an iterator which removes all elements from the table without
-    /// freeing the memory. It is up to the caller to ensure that the `RawTable`
-    /// outlives the `RawDrain`. Because we cannot make the `next` method unsafe
-    /// on the `RawDrain`, we have to make the `drain` method unsafe.
+    /// freeing the memory.
+    ///
+    /// It is up to the caller to ensure that the `RawTable` outlives the `RawDrain`.
+    /// Because we cannot make the `next` method unsafe on the `RawDrain`,
+    /// we have to make the `drain` method unsafe.
     ///
     /// Iteration starts at the provided iterator's current location.
-    ///
-    /// This method panics if the given iterator does not cover all items remaining in the table.
+    /// You must ensure that the iterator covers all items that remain in the table.
     #[cfg_attr(feature = "inline-more", inline)]
     pub unsafe fn drain_iter_from(&mut self, iter: RawIter<T>) -> RawDrain<'_, T> {
         debug_assert_eq!(iter.len(), self.len());
@@ -1032,9 +1035,12 @@ impl<T> RawTable<T> {
 
     /// Returns an iterator which consumes all elements from the table.
     ///
-    /// Iteration starts at the provided iterator's current location.
+    /// It is up to the caller to ensure that the `RawTable` outlives the `RawIntoIter`.
+    /// Because we cannot make the `next` method unsafe on the `RawIntoIter`,
+    /// we have to make the `into_iter_from` method unsafe.
     ///
-    /// This method panics if the given iterator does not cover all items remaining in the table.
+    /// Iteration starts at the provided iterator's current location.
+    /// You must ensure that the iterator covers all items that remain in the table.
     pub unsafe fn into_iter_from(self, iter: RawIter<T>) -> RawIntoIter<T> {
         debug_assert_eq!(iter.len(), self.len());
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1428,7 +1428,8 @@ impl<T> RawIter<T> {
     /// For the iterator to remain valid, this method must be called once
     /// for each removed bucket before `next` is called again.
     ///
-    /// This method should be called _before_ the removal is made.
+    /// This method should be called _before_ the removal is made. It is not necessary to call this
+    /// method if you are removing an item that this iterator yielded in the past.
     #[cfg(feature = "raw")]
     pub fn reflect_remove(&mut self, b: &Bucket<T>) {
         self.reflect_toggle_full(b, false);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1456,7 +1456,9 @@ impl<T> RawIter<T> {
                 return;
             }
 
-            if b.as_ptr() <= self.iter.data.next_n(Group::WIDTH).as_ptr() {
+            if self.iter.next_ctrl < self.iter.end
+                && b.as_ptr() <= self.iter.data.next_n(Group::WIDTH).as_ptr()
+            {
                 // The iterator has not yet reached the bucket's group.
                 // We don't need to reload anything, but we do need to adjust the item count.
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1020,17 +1020,15 @@ impl<T> RawTable<T> {
     /// Iteration starts at the provided iterator's current location.
     ///
     /// This method panics if the given iterator does not cover all items remaining in the table.
-    pub unsafe fn into_iter_from(self, iter: RawIter<T>) -> Option<RawIntoIter<T>> {
-        if iter.len() != self.len() {
-            return None;
-        }
+    pub unsafe fn into_iter_from(self, iter: RawIter<T>) -> RawIntoIter<T> {
+        debug_assert_eq!(iter.len(), self.len());
 
         let alloc = self.into_alloc();
-        Some(RawIntoIter {
+        RawIntoIter {
             iter,
             alloc,
             marker: PhantomData,
-        })
+        }
     }
 
     /// Converts the table into a raw allocation. The contents of the table
@@ -1269,7 +1267,6 @@ impl<T> IntoIterator for RawTable<T> {
         unsafe {
             let iter = self.iter();
             self.into_iter_from(iter)
-                .unwrap_or_else(|| hint::unreachable_unchecked())
         }
     }
 }


### PR DESCRIPTION
Creating a new iterator for a table is occasionally expensive,
especially if a suffix of the table (since we iterate "backwards") is
sparsely populated. This PR adds methods that allow re-using an existing
`RawIter` in more situations.

Replaces #167.
