### PR TITLE
Refactor probing logic into an external iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
     clippy::doc_markdown,
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
-    clippy::option_if_let_else,
+    clippy::option_if_let_else
 )]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
This commit refactors the `RawTable::find` logic into an external iterator, and exposes a new method to create such an iterator.

My motivation was to implement a weak map on top of the raw API.

IIUC, the standard way to implement `insert` is to first call `RawTable::find` to look for an existing bucket. If one is found, replace the value. Otherwise call `RawTable::insert` to create a new bucket.

In a weak map, keys may expire. One optimization for `insert` is to reuse a bucket with an expired key. To do that, you need to keep track of expired buckets during the search stage. This isn't possible with `RawTable::find` because it only gives you access to the element, not the bucket.