### PR TITLE
Removes explicit `ptr_offset_from` since it's stabilized in latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
     feature(
         alloc_layout_extra,
         allocator_api,
-        ptr_offset_from,
         test,
         core_intrinsics,
         dropck_eyepatch,


### PR DESCRIPTION
Should fix #191

This will probably break the build on older nightly compilers. The alternative would be to use `#![allow(stable_features)]` or add `-A stable_features` to `RUSTFLAGS` in the CI setup