### PR TITLE
Bump min rust version in ci to 1.36.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
     - name: "x86_64-unknown-linux-gnu (stable)"
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
-    - name: "x86_64-unknown-linux-gnu (Rust 1.32.0)"
-      rust: 1.32.0
+    - name: "x86_64-unknown-linux-gnu (Rust 1.36.0)"
+      rust: 1.36.0
       env: TARGET=x86_64-unknown-linux-gnu
     - name: "i686-unknown-linux-gnu"
       env: TARGET=i686-unknown-linux-gnu CROSS=1


### PR DESCRIPTION
Needed because latest crossbeam release uses `MaybeUninit` which was stabilized in `1.36.0` .