### PR TITLE
Use the alloc crate on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["hash", "no_std", "hashmap", "swisstable"]
 categories = ["data-structures", "no-std"]
 exclude = [".travis.yml", "bors.toml", "/ci/*"]
 edition = "2018"
-build = "build.rs"
 
 [dependencies]
 # For the default hasher
@@ -24,9 +23,6 @@ serde = { version = "1.0.25", default-features = false, optional = true }
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
 compiler_builtins = { version = "0.1.2", optional = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
-
-[build-dependencies]
-autocfg = "1"
 
 [dev-dependencies]
 lazy_static = "1.2"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    let nightly = std::env::var_os("CARGO_FEATURE_NIGHTLY").is_some();
-    let has_stable_alloc = || autocfg::new().probe_rustc_version(1, 36);
-
-    if nightly || has_stable_alloc() {
-        autocfg::emit("has_extern_crate_alloc")
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
 #![cfg_attr(
     feature = "nightly",
     feature(
-        alloc_layout_extra,
-        allocator_api,
         test,
         core_intrinsics,
         dropck_eyepatch,
@@ -35,11 +33,8 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(has_extern_crate_alloc)]
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
-#[cfg(not(has_extern_crate_alloc))]
-extern crate std as alloc;
 
 #[cfg(feature = "nightly")]
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,7 @@
 #![no_std]
 #![cfg_attr(
     feature = "nightly",
-    feature(
-        test,
-        core_intrinsics,
-        dropck_eyepatch,
-        min_specialization,
-        extend_one,
-    )
+    feature(test, core_intrinsics, dropck_eyepatch, min_specialization, extend_one)
 )]
 #![allow(
     clippy::doc_markdown,


### PR DESCRIPTION
Since the minimum supported Rust version has increased to 1.36 (#193),
the alloc crate no longer requires nightly features.