### PR TITLE
Remove from_key_hashed_nocheck's Q: Hash

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1583,7 +1583,7 @@ impl<'a, K, V, S> RawEntryBuilder<'a, K, V, S> {
     pub fn from_key_hashed_nocheck<Q: ?Sized>(self, hash: u64, k: &Q) -> Option<(&'a K, &'a V)>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Eq,
     {
         self.from_hash(hash, |q| q.borrow().eq(k))
     }


### PR DESCRIPTION
We don't need `Q: Hash` in `RawEntryBuilder::from_key_hashed_nocheck`,
because a hash value is already provided. This makes it consistent with
the same method on `RawEntryBuilderMut` that already lacked `Q: Hash`.