### PR TITLE
Better branch likelyness on stable

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -43,14 +43,23 @@ use self::imp::Group;
 // consistently improves performance by 10-15%.
 #[cfg(feature = "nightly")]
 use core::intrinsics::{likely, unlikely};
+
+#[cfg(not(feature = "nightly"))]
+#[inline]
+#[cold]
+fn cold() {}
+
 #[cfg(not(feature = "nightly"))]
 #[inline]
 fn likely(b: bool) -> bool {
+    if !b { cold() }
     b
 }
 #[cfg(not(feature = "nightly"))]
+#[cold]
 #[inline]
 fn unlikely(b: bool) -> bool {
+    if b { cold() }
     b
 }
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -44,6 +44,8 @@ use self::imp::Group;
 #[cfg(feature = "nightly")]
 use core::intrinsics::{likely, unlikely};
 
+// On stable we can use #[cold] to get a equivalent effect: this attributes
+// suggests that the function is unlikely to be called
 #[cfg(not(feature = "nightly"))]
 #[inline]
 #[cold]
@@ -56,7 +58,6 @@ fn likely(b: bool) -> bool {
     b
 }
 #[cfg(not(feature = "nightly"))]
-#[cold]
 #[inline]
 fn unlikely(b: bool) -> bool {
     if b { cold() }


### PR DESCRIPTION
It uses uses the `#[cold]` attribute to get a similar effect as `core::intrinsics::{likely, unlikely}` on stable (10-15% on some benchmarks)