### PR TITLE
Switch serde test to fnv to avoid 32bit issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-all
 lazy_static = "1.2"
 rand = { version = "0.7.3", features = ["small_rng"] }
 rayon = "1.0"
-rustc-hash = "=1.0"
+fnv = "1.0.7"
 serde_test = "1.0"
 doc-comment = "0.3.1"
 

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -28,6 +28,7 @@ impl Group {
     /// value for an empty hash table.
     ///
     /// This is guaranteed to be aligned to the group size.
+    #[allow(clippy::items_after_statements)]
     pub const fn static_empty() -> &'static [u8; Group::WIDTH] {
         #[repr(C)]
         struct AlignedBytes {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,24 +1,24 @@
 #![cfg(feature = "serde")]
 
 use core::hash::BuildHasherDefault;
+use fnv::FnvHasher;
 use hashbrown::{HashMap, HashSet};
-use rustc_hash::FxHasher;
 use serde_test::{assert_tokens, Token};
 
-// We use FxHash for this test because we rely on the ordering
-type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
-type FxHashSet<T> = HashSet<T, BuildHasherDefault<FxHasher>>;
+// We use FnvHash for this test because we rely on the ordering
+type FnvHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;
+type FnvHashSet<T> = HashSet<T, BuildHasherDefault<FnvHasher>>;
 
 #[test]
 fn map_serde_tokens_empty() {
-    let map = FxHashMap::<char, u32>::default();
+    let map = FnvHashMap::<char, u32>::default();
 
     assert_tokens(&map, &[Token::Map { len: Some(0) }, Token::MapEnd]);
 }
 
 #[test]
 fn map_serde_tokens() {
-    let mut map = FxHashMap::default();
+    let mut map = FnvHashMap::default();
     map.insert('b', 20);
     map.insert('a', 10);
     map.insert('c', 30);
@@ -29,10 +29,10 @@ fn map_serde_tokens() {
             Token::Map { len: Some(3) },
             Token::Char('a'),
             Token::I32(10),
-            Token::Char('b'),
-            Token::I32(20),
             Token::Char('c'),
             Token::I32(30),
+            Token::Char('b'),
+            Token::I32(20),
             Token::MapEnd,
         ],
     );
@@ -40,14 +40,14 @@ fn map_serde_tokens() {
 
 #[test]
 fn set_serde_tokens_empty() {
-    let set = FxHashSet::<u32>::default();
+    let set = FnvHashSet::<u32>::default();
 
     assert_tokens(&set, &[Token::Seq { len: Some(0) }, Token::SeqEnd]);
 }
 
 #[test]
 fn set_serde_tokens() {
-    let mut set = FxHashSet::default();
+    let mut set = FnvHashSet::default();
     set.insert(20);
     set.insert(10);
     set.insert(30);
@@ -56,9 +56,9 @@ fn set_serde_tokens() {
         &set,
         &[
             Token::Seq { len: Some(3) },
+            Token::I32(30),
             Token::I32(20),
             Token::I32(10),
-            Token::I32(30),
             Token::SeqEnd,
         ],
     );


### PR DESCRIPTION
Currently the serde test depends on the order of the items in the hashmap. FxHash uses different multiplication constants on 32bit and 64bit architectures making the test fail if run on 32bit systems.
This switches to fnv which is fully deterministic. 