### PR TITLE
Account for renaming AllocRef to Allocator on nightly

### DIFF
--- a/src/external_trait_impls/rayon/map.rs
+++ b/src/external_trait_impls/rayon/map.rs
@@ -1,7 +1,7 @@
 //! Rayon extensions for `HashMap`.
 
 use crate::hash_map::HashMap;
-use crate::raw::{AllocRef, Global};
+use crate::raw::{Allocator, Global};
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use rayon::iter::plumbing::UnindexedConsumer;
@@ -16,11 +16,11 @@ use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, Pa
 /// [`par_iter`]: /hashbrown/struct.HashMap.html#method.par_iter
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
 /// [`IntoParallelRefIterator`]: https://docs.rs/rayon/1.0/rayon/iter/trait.IntoParallelRefIterator.html
-pub struct ParIter<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct ParIter<'a, K, V, S, A: Allocator + Clone = Global> {
     map: &'a HashMap<K, V, S, A>,
 }
 
-impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator
+impl<'a, K: Sync, V: Sync, S: Sync, A: Allocator + Clone + Sync> ParallelIterator
     for ParIter<'a, K, V, S, A>
 {
     type Item = (&'a K, &'a V);
@@ -39,14 +39,14 @@ impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> Clone for ParIter<'_, K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> Clone for ParIter<'_, K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         ParIter { map: self.map }
     }
 }
 
-impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for ParIter<'_, K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -61,11 +61,11 @@ impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clo
 ///
 /// [`par_keys`]: /hashbrown/struct.HashMap.html#method.par_keys
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
-pub struct ParKeys<'a, K, V, S, A: AllocRef + Clone> {
+pub struct ParKeys<'a, K, V, S, A: Allocator + Clone> {
     map: &'a HashMap<K, V, S, A>,
 }
 
-impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator
+impl<'a, K: Sync, V: Sync, S: Sync, A: Allocator + Clone + Sync> ParallelIterator
     for ParKeys<'a, K, V, S, A>
 {
     type Item = &'a K;
@@ -81,14 +81,14 @@ impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> Clone for ParKeys<'_, K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> Clone for ParKeys<'_, K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         ParKeys { map: self.map }
     }
 }
 
-impl<K: fmt::Debug + Eq + Hash, V, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: fmt::Debug + Eq + Hash, V, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for ParKeys<'_, K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -103,11 +103,11 @@ impl<K: fmt::Debug + Eq + Hash, V, S: BuildHasher, A: AllocRef + Clone> fmt::Deb
 ///
 /// [`par_values`]: /hashbrown/struct.HashMap.html#method.par_values
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
-pub struct ParValues<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct ParValues<'a, K, V, S, A: Allocator + Clone = Global> {
     map: &'a HashMap<K, V, S, A>,
 }
 
-impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator
+impl<'a, K: Sync, V: Sync, S: Sync, A: Allocator + Clone + Sync> ParallelIterator
     for ParValues<'a, K, V, S, A>
 {
     type Item = &'a V;
@@ -123,14 +123,14 @@ impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> Clone for ParValues<'_, K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> Clone for ParValues<'_, K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         ParValues { map: self.map }
     }
 }
 
-impl<K: Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: Eq + Hash, V: fmt::Debug, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for ParValues<'_, K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -147,11 +147,11 @@ impl<K: Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debu
 /// [`par_iter_mut`]: /hashbrown/struct.HashMap.html#method.par_iter_mut
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
 /// [`IntoParallelRefMutIterator`]: https://docs.rs/rayon/1.0/rayon/iter/trait.IntoParallelRefMutIterator.html
-pub struct ParIterMut<'a, K, V, S, A: AllocRef + Clone> {
+pub struct ParIterMut<'a, K, V, S, A: Allocator + Clone> {
     map: &'a mut HashMap<K, V, S, A>,
 }
 
-impl<'a, K: Send + Sync, V: Send, S: Send, A: AllocRef + Clone + Sync> ParallelIterator
+impl<'a, K: Send + Sync, V: Send, S: Send, A: Allocator + Clone + Sync> ParallelIterator
     for ParIterMut<'a, K, V, S, A>
 {
     type Item = (&'a K, &'a mut V);
@@ -170,7 +170,7 @@ impl<'a, K: Send + Sync, V: Send, S: Send, A: AllocRef + Clone + Sync> ParallelI
     }
 }
 
-impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for ParIterMut<'_, K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -185,11 +185,11 @@ impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clo
 ///
 /// [`par_values_mut`]: /hashbrown/struct.HashMap.html#method.par_values_mut
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
-pub struct ParValuesMut<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct ParValuesMut<'a, K, V, S, A: Allocator + Clone = Global> {
     map: &'a mut HashMap<K, V, S, A>,
 }
 
-impl<'a, K: Send, V: Send, S: Send, A: AllocRef + Clone + Send> ParallelIterator
+impl<'a, K: Send, V: Send, S: Send, A: Allocator + Clone + Send> ParallelIterator
     for ParValuesMut<'a, K, V, S, A>
 {
     type Item = &'a mut V;
@@ -205,7 +205,7 @@ impl<'a, K: Send, V: Send, S: Send, A: AllocRef + Clone + Send> ParallelIterator
     }
 }
 
-impl<K: Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: Eq + Hash, V: fmt::Debug, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for ParValuesMut<'_, K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -222,11 +222,11 @@ impl<K: Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debu
 /// [`into_par_iter`]: /hashbrown/struct.HashMap.html#method.into_par_iter
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
 /// [`IntoParallelIterator`]: https://docs.rs/rayon/1.0/rayon/iter/trait.IntoParallelIterator.html
-pub struct IntoParIter<K, V, S, A: AllocRef + Clone = Global> {
+pub struct IntoParIter<K, V, S, A: Allocator + Clone = Global> {
     map: HashMap<K, V, S, A>,
 }
 
-impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Send> ParallelIterator
+impl<K: Send, V: Send, S: Send, A: Allocator + Clone + Send> ParallelIterator
     for IntoParIter<K, V, S, A>
 {
     type Item = (K, V);
@@ -240,7 +240,7 @@ impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Send> ParallelIterator
     }
 }
 
-impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for IntoParIter<K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -255,11 +255,11 @@ impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clo
 ///
 /// [`par_drain`]: /hashbrown/struct.HashMap.html#method.par_drain
 /// [`HashMap`]: /hashbrown/struct.HashMap.html
-pub struct ParDrain<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct ParDrain<'a, K, V, S, A: Allocator + Clone = Global> {
     map: &'a mut HashMap<K, V, S, A>,
 }
 
-impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Sync> ParallelIterator
+impl<K: Send, V: Send, S: Send, A: Allocator + Clone + Sync> ParallelIterator
     for ParDrain<'_, K, V, S, A>
 {
     type Item = (K, V);
@@ -273,7 +273,7 @@ impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Sync> ParallelIterator
     }
 }
 
-impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clone> fmt::Debug
+impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: Allocator + Clone> fmt::Debug
     for ParDrain<'_, K, V, S, A>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -281,7 +281,7 @@ impl<K: fmt::Debug + Eq + Hash, V: fmt::Debug, S: BuildHasher, A: AllocRef + Clo
     }
 }
 
-impl<K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> HashMap<K, V, S, A> {
+impl<K: Sync, V: Sync, S: Sync, A: Allocator + Clone + Sync> HashMap<K, V, S, A> {
     /// Visits (potentially in parallel) immutably borrowed keys in an arbitrary order.
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn par_keys(&self) -> ParKeys<'_, K, V, S, A> {
@@ -295,7 +295,7 @@ impl<K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> HashMap<K, V, S, A> 
     }
 }
 
-impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Sync> HashMap<K, V, S, A> {
+impl<K: Send, V: Send, S: Send, A: Allocator + Clone + Sync> HashMap<K, V, S, A> {
     /// Visits (potentially in parallel) mutably borrowed values in an arbitrary order.
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn par_values_mut(&mut self) -> ParValuesMut<'_, K, V, S, A> {
@@ -315,7 +315,7 @@ where
     K: Eq + Hash + Sync,
     V: PartialEq + Sync,
     S: BuildHasher + Sync,
-    A: AllocRef + Clone + Sync,
+    A: Allocator + Clone + Sync,
 {
     /// Returns `true` if the map is equal to another,
     /// i.e. both maps contain the same keys mapped to the same values.
@@ -329,7 +329,7 @@ where
     }
 }
 
-impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Send> IntoParallelIterator
+impl<K: Send, V: Send, S: Send, A: Allocator + Clone + Send> IntoParallelIterator
     for HashMap<K, V, S, A>
 {
     type Item = (K, V);
@@ -341,7 +341,7 @@ impl<K: Send, V: Send, S: Send, A: AllocRef + Clone + Send> IntoParallelIterator
     }
 }
 
-impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> IntoParallelIterator
+impl<'a, K: Sync, V: Sync, S: Sync, A: Allocator + Clone + Sync> IntoParallelIterator
     for &'a HashMap<K, V, S, A>
 {
     type Item = (&'a K, &'a V);
@@ -353,7 +353,7 @@ impl<'a, K: Sync, V: Sync, S: Sync, A: AllocRef + Clone + Sync> IntoParallelIter
     }
 }
 
-impl<'a, K: Send + Sync, V: Send, S: Send, A: AllocRef + Clone + Sync> IntoParallelIterator
+impl<'a, K: Send + Sync, V: Send, S: Send, A: Allocator + Clone + Sync> IntoParallelIterator
     for &'a mut HashMap<K, V, S, A>
 {
     type Item = (&'a K, &'a mut V);
@@ -391,7 +391,7 @@ where
     K: Eq + Hash + Send,
     V: Send,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -407,7 +407,7 @@ where
     K: Copy + Eq + Hash + Sync,
     V: Copy + Sync,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn par_extend<I>(&mut self, par_iter: I)
     where
@@ -423,7 +423,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
     I: IntoParallelIterator,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
     HashMap<K, V, S, A>: Extend<I::Item>,
 {
     let (list, len) = super::helpers::collect(par_iter);

--- a/src/external_trait_impls/rayon/set.rs
+++ b/src/external_trait_impls/rayon/set.rs
@@ -1,7 +1,7 @@
 //! Rayon extensions for `HashSet`.
 
 use crate::hash_set::HashSet;
-use crate::raw::{AllocRef, Global};
+use crate::raw::{Allocator, Global};
 use core::hash::{BuildHasher, Hash};
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
@@ -15,11 +15,11 @@ use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, Pa
 /// [`into_par_iter`]: /hashbrown/struct.HashSet.html#method.into_par_iter
 /// [`HashSet`]: /hashbrown/struct.HashSet.html
 /// [`IntoParallelIterator`]: https://docs.rs/rayon/1.0/rayon/iter/trait.IntoParallelIterator.html
-pub struct IntoParIter<T, S, A: AllocRef + Clone = Global> {
+pub struct IntoParIter<T, S, A: Allocator + Clone = Global> {
     set: HashSet<T, S, A>,
 }
 
-impl<T: Send, S: Send, A: AllocRef + Clone + Send> ParallelIterator for IntoParIter<T, S, A> {
+impl<T: Send, S: Send, A: Allocator + Clone + Send> ParallelIterator for IntoParIter<T, S, A> {
     type Item = T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -41,11 +41,11 @@ impl<T: Send, S: Send, A: AllocRef + Clone + Send> ParallelIterator for IntoParI
 ///
 /// [`par_drain`]: /hashbrown/struct.HashSet.html#method.par_drain
 /// [`HashSet`]: /hashbrown/struct.HashSet.html
-pub struct ParDrain<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct ParDrain<'a, T, S, A: Allocator + Clone = Global> {
     set: &'a mut HashSet<T, S, A>,
 }
 
-impl<T: Send, S: Send, A: AllocRef + Clone + Send + Sync> ParallelIterator
+impl<T: Send, S: Send, A: Allocator + Clone + Send + Sync> ParallelIterator
     for ParDrain<'_, T, S, A>
 {
     type Item = T;
@@ -71,11 +71,11 @@ impl<T: Send, S: Send, A: AllocRef + Clone + Send + Sync> ParallelIterator
 /// [`par_iter`]: /hashbrown/struct.HashSet.html#method.par_iter
 /// [`HashSet`]: /hashbrown/struct.HashSet.html
 /// [`IntoParallelRefIterator`]: https://docs.rs/rayon/1.0/rayon/iter/trait.IntoParallelRefIterator.html
-pub struct ParIter<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct ParIter<'a, T, S, A: Allocator + Clone = Global> {
     set: &'a HashSet<T, S, A>,
 }
 
-impl<'a, T: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator for ParIter<'a, T, S, A> {
+impl<'a, T: Sync, S: Sync, A: Allocator + Clone + Sync> ParallelIterator for ParIter<'a, T, S, A> {
     type Item = &'a T;
 
     fn drive_unindexed<C>(self, consumer: C) -> C::Result
@@ -94,7 +94,7 @@ impl<'a, T: Sync, S: Sync, A: AllocRef + Clone + Sync> ParallelIterator for ParI
 ///
 /// [`par_difference`]: /hashbrown/struct.HashSet.html#method.par_difference
 /// [`HashSet`]: /hashbrown/struct.HashSet.html
-pub struct ParDifference<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct ParDifference<'a, T, S, A: Allocator + Clone = Global> {
     a: &'a HashSet<T, S, A>,
     b: &'a HashSet<T, S, A>,
 }
@@ -103,7 +103,7 @@ impl<'a, T, S, A> ParallelIterator for ParDifference<'a, T, S, A>
 where
     T: Eq + Hash + Sync,
     S: BuildHasher + Sync,
-    A: AllocRef + Clone + Sync,
+    A: Allocator + Clone + Sync,
 {
     type Item = &'a T;
 
@@ -127,7 +127,7 @@ where
 ///
 /// [`par_symmetric_difference`]: /hashbrown/struct.HashSet.html#method.par_symmetric_difference
 /// [`HashSet`]: /hashbrown/struct.HashSet.html
-pub struct ParSymmetricDifference<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct ParSymmetricDifference<'a, T, S, A: Allocator + Clone = Global> {
     a: &'a HashSet<T, S, A>,
     b: &'a HashSet<T, S, A>,
 }
@@ -136,7 +136,7 @@ impl<'a, T, S, A> ParallelIterator for ParSymmetricDifference<'a, T, S, A>
 where
     T: Eq + Hash + Sync,
     S: BuildHasher + Sync,
-    A: AllocRef + Clone + Sync,
+    A: Allocator + Clone + Sync,
 {
     type Item = &'a T;
 
@@ -159,7 +159,7 @@ where
 ///
 /// [`par_intersection`]: /hashbrown/struct.HashSet.html#method.par_intersection
 /// [`HashSet`]: /hashbrown/struct.HashSet.html
-pub struct ParIntersection<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct ParIntersection<'a, T, S, A: Allocator + Clone = Global> {
     a: &'a HashSet<T, S, A>,
     b: &'a HashSet<T, S, A>,
 }
@@ -168,7 +168,7 @@ impl<'a, T, S, A> ParallelIterator for ParIntersection<'a, T, S, A>
 where
     T: Eq + Hash + Sync,
     S: BuildHasher + Sync,
-    A: AllocRef + Clone + Sync,
+    A: Allocator + Clone + Sync,
 {
     type Item = &'a T;
 
@@ -230,7 +230,7 @@ impl<T, S, A> HashSet<T, S, A>
 where
     T: Eq + Hash + Sync,
     S: BuildHasher + Sync,
-    A: AllocRef + Clone + Sync,
+    A: Allocator + Clone + Sync,
 {
     /// Visits (potentially in parallel) the values representing the difference,
     /// i.e. the values that are in `self` but not in `other`.
@@ -297,7 +297,7 @@ impl<T, S, A> HashSet<T, S, A>
 where
     T: Eq + Hash + Send,
     S: BuildHasher + Send,
-    A: AllocRef + Clone + Send,
+    A: Allocator + Clone + Send,
 {
     /// Consumes (potentially in parallel) all values in an arbitrary order,
     /// while preserving the set's allocated memory for reuse.
@@ -307,7 +307,7 @@ where
     }
 }
 
-impl<T: Send, S: Send, A: AllocRef + Clone + Send> IntoParallelIterator for HashSet<T, S, A> {
+impl<T: Send, S: Send, A: Allocator + Clone + Send> IntoParallelIterator for HashSet<T, S, A> {
     type Item = T;
     type Iter = IntoParIter<T, S, A>;
 
@@ -317,7 +317,7 @@ impl<T: Send, S: Send, A: AllocRef + Clone + Send> IntoParallelIterator for Hash
     }
 }
 
-impl<'a, T: Sync, S: Sync, A: AllocRef + Clone + Sync> IntoParallelIterator
+impl<'a, T: Sync, S: Sync, A: Allocator + Clone + Sync> IntoParallelIterator
     for &'a HashSet<T, S, A>
 {
     type Item = &'a T;
@@ -378,7 +378,7 @@ fn extend<T, S, I, A>(set: &mut HashSet<T, S, A>, par_iter: I)
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
     I: IntoParallelIterator,
     HashSet<T, S, A>: Extend<I::Item>,
 {

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,4 @@
-use crate::raw::{AllocRef, Bucket, Global, RawDrain, RawIntoIter, RawIter, RawTable};
+use crate::raw::{Allocator, Bucket, Global, RawDrain, RawIntoIter, RawIter, RawTable};
 use crate::TryReserveError;
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
@@ -185,7 +185,7 @@ pub enum DefaultHashBuilder {}
 ///     .iter().cloned().collect();
 /// // use the values stored in map
 /// ```
-pub struct HashMap<K, V, S = DefaultHashBuilder, A: AllocRef + Clone = Global> {
+pub struct HashMap<K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
     pub(crate) hash_builder: S,
     pub(crate) table: RawTable<(K, V), A>,
 }
@@ -280,7 +280,7 @@ impl<K, V> HashMap<K, V, DefaultHashBuilder> {
 }
 
 #[cfg(feature = "ahash")]
-impl<K, V, A: AllocRef + Clone> HashMap<K, V, DefaultHashBuilder, A> {
+impl<K, V, A: Allocator + Clone> HashMap<K, V, DefaultHashBuilder, A> {
     /// Creates an empty `HashMap` using the given allocator.
     ///
     /// The hash map is initially created with a capacity of 0, so it will not allocate until it
@@ -369,7 +369,7 @@ impl<K, V, S> HashMap<K, V, S> {
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> HashMap<K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// Creates an empty `HashMap` which will use the given hash builder to hash
     /// keys. It will be allocated with the given allocator.
     ///
@@ -754,7 +754,7 @@ impl<K, V, S, A> HashMap<K, V, S, A>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     /// Reserves capacity for at least `additional` more elements to be inserted
     /// in the `HashMap`. The collection may reserve more space to avoid
@@ -1172,7 +1172,7 @@ where
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> HashMap<K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// Creates a raw entry builder for the HashMap.
     ///
     /// Raw entries provide the lowest level of control for searching and
@@ -1235,7 +1235,7 @@ where
     K: Eq + Hash,
     V: PartialEq,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
@@ -1252,7 +1252,7 @@ where
     K: Eq + Hash,
     V: Eq,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
 }
 
@@ -1260,7 +1260,7 @@ impl<K, V, S, A> Debug for HashMap<K, V, S, A>
 where
     K: Debug,
     V: Debug,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
@@ -1270,7 +1270,7 @@ where
 impl<K, V, S, A> Default for HashMap<K, V, S, A>
 where
     S: Default,
-    A: Default + AllocRef + Clone,
+    A: Default + Allocator + Clone,
 {
     /// Creates an empty `HashMap<K, V, S, A>`, with the `Default` value for the hasher and allocator.
     #[cfg_attr(feature = "inline-more", inline)]
@@ -1284,7 +1284,7 @@ where
     K: Eq + Hash + Borrow<Q>,
     Q: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Output = V;
 
@@ -1364,11 +1364,11 @@ impl<K, V> IterMut<'_, K, V> {
 ///
 /// [`into_iter`]: struct.HashMap.html#method.into_iter
 /// [`HashMap`]: struct.HashMap.html
-pub struct IntoIter<K, V, A: AllocRef + Clone = Global> {
+pub struct IntoIter<K, V, A: Allocator + Clone = Global> {
     inner: RawIntoIter<(K, V), A>,
 }
 
-impl<K, V, A: AllocRef + Clone> IntoIter<K, V, A> {
+impl<K, V, A: Allocator + Clone> IntoIter<K, V, A> {
     /// Returns a iterator of references over the remaining items.
     #[cfg_attr(feature = "inline-more", inline)]
     pub(super) fn iter(&self) -> Iter<'_, K, V> {
@@ -1440,11 +1440,11 @@ impl<K, V: Debug> fmt::Debug for Values<'_, K, V> {
 ///
 /// [`drain`]: struct.HashMap.html#method.drain
 /// [`HashMap`]: struct.HashMap.html
-pub struct Drain<'a, K, V, A: AllocRef + Clone = Global> {
+pub struct Drain<'a, K, V, A: Allocator + Clone = Global> {
     inner: RawDrain<'a, (K, V), A>,
 }
 
-impl<K, V, A: AllocRef + Clone> Drain<'_, K, V, A> {
+impl<K, V, A: Allocator + Clone> Drain<'_, K, V, A> {
     /// Returns a iterator of references over the remaining items.
     #[cfg_attr(feature = "inline-more", inline)]
     pub(super) fn iter(&self) -> Iter<'_, K, V> {
@@ -1462,7 +1462,7 @@ impl<K, V, A: AllocRef + Clone> Drain<'_, K, V, A> {
 ///
 /// [`drain_filter`]: struct.HashMap.html#method.drain_filter
 /// [`HashMap`]: struct.HashMap.html
-pub struct DrainFilter<'a, K, V, F, A: AllocRef + Clone = Global>
+pub struct DrainFilter<'a, K, V, F, A: Allocator + Clone = Global>
 where
     F: FnMut(&K, &mut V) -> bool,
 {
@@ -1473,7 +1473,7 @@ where
 impl<'a, K, V, F, A> Drop for DrainFilter<'a, K, V, F, A>
 where
     F: FnMut(&K, &mut V) -> bool,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn drop(&mut self) {
@@ -1497,7 +1497,7 @@ impl<T: Iterator> Drop for ConsumeAllOnDrop<'_, T> {
 impl<K, V, F, A> Iterator for DrainFilter<'_, K, V, F, A>
 where
     F: FnMut(&K, &mut V) -> bool,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Item = (K, V);
 
@@ -1515,12 +1515,12 @@ where
 impl<K, V, F> FusedIterator for DrainFilter<'_, K, V, F> where F: FnMut(&K, &mut V) -> bool {}
 
 /// Portions of `DrainFilter` shared with `set::DrainFilter`
-pub(super) struct DrainFilterInner<'a, K, V, A: AllocRef + Clone> {
+pub(super) struct DrainFilterInner<'a, K, V, A: Allocator + Clone> {
     pub iter: RawIter<(K, V)>,
     pub table: &'a mut RawTable<(K, V), A>,
 }
 
-impl<K, V, A: AllocRef + Clone> DrainFilterInner<'_, K, V, A> {
+impl<K, V, A: Allocator + Clone> DrainFilterInner<'_, K, V, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     pub(super) fn next<F>(&mut self, f: &mut F) -> Option<(K, V)>
     where
@@ -1554,7 +1554,7 @@ pub struct ValuesMut<'a, K, V> {
 /// See the [`HashMap::raw_entry_mut`] docs for usage examples.
 ///
 /// [`HashMap::raw_entry_mut`]: struct.HashMap.html#method.raw_entry_mut
-pub struct RawEntryBuilderMut<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct RawEntryBuilderMut<'a, K, V, S, A: Allocator + Clone = Global> {
     map: &'a mut HashMap<K, V, S, A>,
 }
 
@@ -1569,7 +1569,7 @@ pub struct RawEntryBuilderMut<'a, K, V, S, A: AllocRef + Clone = Global> {
 /// [`Entry`]: enum.Entry.html
 /// [`raw_entry_mut`]: struct.HashMap.html#method.raw_entry_mut
 /// [`RawEntryBuilderMut`]: struct.RawEntryBuilderMut.html
-pub enum RawEntryMut<'a, K, V, S, A: AllocRef + Clone> {
+pub enum RawEntryMut<'a, K, V, S, A: Allocator + Clone> {
     /// An occupied entry.
     Occupied(RawOccupiedEntryMut<'a, K, V, S, A>),
     /// A vacant entry.
@@ -1580,7 +1580,7 @@ pub enum RawEntryMut<'a, K, V, S, A: AllocRef + Clone> {
 /// It is part of the [`RawEntryMut`] enum.
 ///
 /// [`RawEntryMut`]: enum.RawEntryMut.html
-pub struct RawOccupiedEntryMut<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct RawOccupiedEntryMut<'a, K, V, S, A: Allocator + Clone = Global> {
     elem: Bucket<(K, V)>,
     table: &'a mut RawTable<(K, V), A>,
     hash_builder: &'a S,
@@ -1590,14 +1590,14 @@ unsafe impl<K, V, S, A> Send for RawOccupiedEntryMut<'_, K, V, S, A>
 where
     K: Send,
     V: Send,
-    A: Send + AllocRef + Clone,
+    A: Send + Allocator + Clone,
 {
 }
 unsafe impl<K, V, S, A> Sync for RawOccupiedEntryMut<'_, K, V, S, A>
 where
     K: Sync,
     V: Sync,
-    A: Send + AllocRef + Clone,
+    A: Send + Allocator + Clone,
 {
 }
 
@@ -1605,7 +1605,7 @@ where
 /// It is part of the [`RawEntryMut`] enum.
 ///
 /// [`RawEntryMut`]: enum.RawEntryMut.html
-pub struct RawVacantEntryMut<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct RawVacantEntryMut<'a, K, V, S, A: Allocator + Clone = Global> {
     table: &'a mut RawTable<(K, V), A>,
     hash_builder: &'a S,
 }
@@ -1615,11 +1615,11 @@ pub struct RawVacantEntryMut<'a, K, V, S, A: AllocRef + Clone = Global> {
 /// See the [`HashMap::raw_entry`] docs for usage examples.
 ///
 /// [`HashMap::raw_entry`]: struct.HashMap.html#method.raw_entry
-pub struct RawEntryBuilder<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct RawEntryBuilder<'a, K, V, S, A: Allocator + Clone = Global> {
     map: &'a HashMap<K, V, S, A>,
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
     /// Creates a `RawEntryMut` from the given key.
     #[cfg_attr(feature = "inline-more", inline)]
     #[allow(clippy::wrong_self_convention)]
@@ -1646,7 +1646,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
     /// Creates a `RawEntryMut` from the given hash.
     #[cfg_attr(feature = "inline-more", inline)]
     #[allow(clippy::wrong_self_convention)]
@@ -1676,7 +1676,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> RawEntryBuilder<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilder<'a, K, V, S, A> {
     /// Access an entry by key.
     #[cfg_attr(feature = "inline-more", inline)]
     #[allow(clippy::wrong_self_convention)]
@@ -1724,7 +1724,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> RawEntryBuilder<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> RawEntryMut<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> RawEntryMut<'a, K, V, S, A> {
     /// Sets the value of the entry, and returns a RawOccupiedEntryMut.
     ///
     /// # Examples
@@ -1918,7 +1918,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> RawEntryMut<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> RawOccupiedEntryMut<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> RawOccupiedEntryMut<'a, K, V, S, A> {
     /// Gets a reference to the key in the entry.
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn key(&self) -> &K {
@@ -2036,7 +2036,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> RawOccupiedEntryMut<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> RawVacantEntryMut<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> RawVacantEntryMut<'a, K, V, S, A> {
     /// Sets the value of the entry with the VacantEntry's key,
     /// and returns a mutable reference to it.
     #[cfg_attr(feature = "inline-more", inline)]
@@ -2105,13 +2105,13 @@ impl<'a, K, V, S, A: AllocRef + Clone> RawVacantEntryMut<'a, K, V, S, A> {
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> Debug for RawEntryBuilderMut<'_, K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> Debug for RawEntryBuilderMut<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
 }
 
-impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for RawEntryMut<'_, K, V, S, A> {
+impl<K: Debug, V: Debug, S, A: Allocator + Clone> Debug for RawEntryMut<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             RawEntryMut::Vacant(ref v) => f.debug_tuple("RawEntry").field(v).finish(),
@@ -2120,7 +2120,7 @@ impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for RawEntryMut<'_, K, V,
     }
 }
 
-impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for RawOccupiedEntryMut<'_, K, V, S, A> {
+impl<K: Debug, V: Debug, S, A: Allocator + Clone> Debug for RawOccupiedEntryMut<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawOccupiedEntryMut")
             .field("key", self.key())
@@ -2129,13 +2129,13 @@ impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for RawOccupiedEntryMut<'
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> Debug for RawVacantEntryMut<'_, K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> Debug for RawVacantEntryMut<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawVacantEntryMut").finish()
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> Debug for RawEntryBuilder<'_, K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> Debug for RawEntryBuilder<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
@@ -2149,7 +2149,7 @@ impl<K, V, S, A: AllocRef + Clone> Debug for RawEntryBuilder<'_, K, V, S, A> {
 /// [`entry`]: struct.HashMap.html#method.entry
 pub enum Entry<'a, K, V, S, A>
 where
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     /// An occupied entry.
     Occupied(OccupiedEntry<'a, K, V, S, A>),
@@ -2158,7 +2158,7 @@ where
     Vacant(VacantEntry<'a, K, V, S, A>),
 }
 
-impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for Entry<'_, K, V, S, A> {
+impl<K: Debug, V: Debug, S, A: Allocator + Clone> Debug for Entry<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Entry::Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
@@ -2171,7 +2171,7 @@ impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for Entry<'_, K, V, S, A>
 /// It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct OccupiedEntry<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct OccupiedEntry<'a, K, V, S, A: Allocator + Clone = Global> {
     hash: u64,
     key: Option<K>,
     elem: Bucket<(K, V)>,
@@ -2183,7 +2183,7 @@ where
     K: Send,
     V: Send,
     S: Send,
-    A: Send + AllocRef + Clone,
+    A: Send + Allocator + Clone,
 {
 }
 unsafe impl<K, V, S, A> Sync for OccupiedEntry<'_, K, V, S, A>
@@ -2191,11 +2191,11 @@ where
     K: Sync,
     V: Sync,
     S: Sync,
-    A: Sync + AllocRef + Clone,
+    A: Sync + Allocator + Clone,
 {
 }
 
-impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for OccupiedEntry<'_, K, V, S, A> {
+impl<K: Debug, V: Debug, S, A: Allocator + Clone> Debug for OccupiedEntry<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("key", self.key())
@@ -2208,19 +2208,19 @@ impl<K: Debug, V: Debug, S, A: AllocRef + Clone> Debug for OccupiedEntry<'_, K, 
 /// It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct VacantEntry<'a, K, V, S, A: AllocRef + Clone = Global> {
+pub struct VacantEntry<'a, K, V, S, A: Allocator + Clone = Global> {
     hash: u64,
     key: K,
     table: &'a mut HashMap<K, V, S, A>,
 }
 
-impl<K: Debug, V, S, A: AllocRef + Clone> Debug for VacantEntry<'_, K, V, S, A> {
+impl<K: Debug, V, S, A: Allocator + Clone> Debug for VacantEntry<'_, K, V, S, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VacantEntry").field(self.key()).finish()
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> IntoIterator for &'a HashMap<K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> IntoIterator for &'a HashMap<K, V, S, A> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
@@ -2230,7 +2230,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> IntoIterator for &'a HashMap<K, V, S, A> 
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> IntoIterator for &'a mut HashMap<K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> IntoIterator for &'a mut HashMap<K, V, S, A> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
@@ -2240,7 +2240,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> IntoIterator for &'a mut HashMap<K, V, S,
     }
 }
 
-impl<K, V, S, A: AllocRef + Clone> IntoIterator for HashMap<K, V, S, A> {
+impl<K, V, S, A: Allocator + Clone> IntoIterator for HashMap<K, V, S, A> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V, A>;
 
@@ -2334,7 +2334,7 @@ where
     }
 }
 
-impl<K, V, A: AllocRef + Clone> Iterator for IntoIter<K, V, A> {
+impl<K, V, A: Allocator + Clone> Iterator for IntoIter<K, V, A> {
     type Item = (K, V);
 
     #[cfg_attr(feature = "inline-more", inline)]
@@ -2346,15 +2346,15 @@ impl<K, V, A: AllocRef + Clone> Iterator for IntoIter<K, V, A> {
         self.inner.size_hint()
     }
 }
-impl<K, V, A: AllocRef + Clone> ExactSizeIterator for IntoIter<K, V, A> {
+impl<K, V, A: Allocator + Clone> ExactSizeIterator for IntoIter<K, V, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
-impl<K, V, A: AllocRef + Clone> FusedIterator for IntoIter<K, V, A> {}
+impl<K, V, A: Allocator + Clone> FusedIterator for IntoIter<K, V, A> {}
 
-impl<K: Debug, V: Debug, A: AllocRef + Clone> fmt::Debug for IntoIter<K, V, A> {
+impl<K: Debug, V: Debug, A: Allocator + Clone> fmt::Debug for IntoIter<K, V, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -2442,7 +2442,7 @@ where
     }
 }
 
-impl<'a, K, V, A: AllocRef + Clone> Iterator for Drain<'a, K, V, A> {
+impl<'a, K, V, A: Allocator + Clone> Iterator for Drain<'a, K, V, A> {
     type Item = (K, V);
 
     #[cfg_attr(feature = "inline-more", inline)]
@@ -2454,26 +2454,26 @@ impl<'a, K, V, A: AllocRef + Clone> Iterator for Drain<'a, K, V, A> {
         self.inner.size_hint()
     }
 }
-impl<K, V, A: AllocRef + Clone> ExactSizeIterator for Drain<'_, K, V, A> {
+impl<K, V, A: Allocator + Clone> ExactSizeIterator for Drain<'_, K, V, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.inner.len()
     }
 }
-impl<K, V, A: AllocRef + Clone> FusedIterator for Drain<'_, K, V, A> {}
+impl<K, V, A: Allocator + Clone> FusedIterator for Drain<'_, K, V, A> {}
 
 impl<K, V, A> fmt::Debug for Drain<'_, K, V, A>
 where
     K: fmt::Debug,
     V: fmt::Debug,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> Entry<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> Entry<'a, K, V, S, A> {
     /// Sets the value of the entry, and returns an OccupiedEntry.
     ///
     /// # Examples
@@ -2704,7 +2704,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> Entry<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V: Default, S, A: AllocRef + Clone> Entry<'a, K, V, S, A> {
+impl<'a, K, V: Default, S, A: Allocator + Clone> Entry<'a, K, V, S, A> {
     /// Ensures a value is in the entry by inserting the default value if empty,
     /// and returns a mutable reference to the value in the entry.
     ///
@@ -2731,7 +2731,7 @@ impl<'a, K, V: Default, S, A: AllocRef + Clone> Entry<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> OccupiedEntry<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> OccupiedEntry<'a, K, V, S, A> {
     /// Gets a reference to the key in the entry.
     ///
     /// # Examples
@@ -3037,7 +3037,7 @@ impl<'a, K, V, S, A: AllocRef + Clone> OccupiedEntry<'a, K, V, S, A> {
     }
 }
 
-impl<'a, K, V, S, A: AllocRef + Clone> VacantEntry<'a, K, V, S, A> {
+impl<'a, K, V, S, A: Allocator + Clone> VacantEntry<'a, K, V, S, A> {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `VacantEntry`.
     ///
@@ -3128,7 +3128,7 @@ impl<K, V, S, A> FromIterator<(K, V)> for HashMap<K, V, S, A>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,
-    A: Default + AllocRef + Clone,
+    A: Default + Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
@@ -3148,7 +3148,7 @@ impl<K, V, S, A> Extend<(K, V)> for HashMap<K, V, S, A>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
@@ -3195,7 +3195,7 @@ where
     K: Eq + Hash + Copy,
     V: Copy,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: T) {
@@ -3229,12 +3229,12 @@ fn assert_covariance() {
     fn iter_val<'a, 'new>(v: Iter<'a, u8, &'static str>) -> Iter<'a, u8, &'new str> {
         v
     }
-    fn into_iter_key<'new, A: AllocRef + Clone>(
+    fn into_iter_key<'new, A: Allocator + Clone>(
         v: IntoIter<&'static str, u8, A>,
     ) -> IntoIter<&'new str, u8, A> {
         v
     }
-    fn into_iter_val<'new, A: AllocRef + Clone>(
+    fn into_iter_val<'new, A: Allocator + Clone>(
         v: IntoIter<u8, &'static str, A>,
     ) -> IntoIter<u8, &'new str, A> {
         v

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -3,13 +3,13 @@ pub use self::inner::*;
 #[cfg(feature = "nightly")]
 mod inner {
     use crate::alloc::alloc::Layout;
-    pub use crate::alloc::alloc::{AllocRef, Global};
+    pub use crate::alloc::alloc::{Allocator, Global};
     use core::ptr::NonNull;
 
     #[allow(clippy::map_err_ignore)]
-    pub fn do_alloc<A: AllocRef>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+    pub fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
         alloc
-            .alloc(layout)
+            .allocate(layout)
             .map(|ptr| ptr.as_non_null_ptr())
             .map_err(|_| ())
     }
@@ -22,18 +22,18 @@ mod inner {
 
     pub struct AllocError;
 
-    pub unsafe trait AllocRef {
-        fn alloc(&self, layout: Layout) -> Result<NonNull<u8>, AllocError>;
-        unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout);
+    pub unsafe trait Allocator {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError>;
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
     }
 
     #[derive(Copy, Clone)]
     pub struct Global;
-    unsafe impl AllocRef for Global {
-        fn alloc(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+    unsafe impl Allocator for Global {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
             unsafe { NonNull::new(alloc(layout)).ok_or(AllocError) }
         }
-        unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             dealloc(ptr.as_ptr(), layout)
         }
     }
@@ -44,7 +44,7 @@ mod inner {
     }
 
     #[allow(clippy::map_err_ignore)]
-    pub fn do_alloc<A: AllocRef>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
-        alloc.alloc(layout).map_err(|_| ())
+    pub fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
+        alloc.allocate(layout).map_err(|_| ())
     }
 }

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -1,6 +1,6 @@
 use self::RustcEntry::*;
 use crate::map::{make_hash, Drain, HashMap, IntoIter, Iter, IterMut};
-use crate::raw::{AllocRef, Bucket, Global, RawTable};
+use crate::raw::{Allocator, Bucket, Global, RawTable};
 use core::fmt::{self, Debug};
 use core::hash::{BuildHasher, Hash};
 use core::mem;
@@ -9,7 +9,7 @@ impl<K, V, S, A> HashMap<K, V, S, A>
 where
     K: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
     ///
@@ -62,7 +62,7 @@ where
 /// [`entry`]: struct.HashMap.html#method.rustc_entry
 pub enum RustcEntry<'a, K, V, A = Global>
 where
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     /// An occupied entry.
     Occupied(RustcOccupiedEntry<'a, K, V, A>),
@@ -71,7 +71,7 @@ where
     Vacant(RustcVacantEntry<'a, K, V, A>),
 }
 
-impl<K: Debug, V: Debug, A: AllocRef + Clone> Debug for RustcEntry<'_, K, V, A> {
+impl<K: Debug, V: Debug, A: Allocator + Clone> Debug for RustcEntry<'_, K, V, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
@@ -86,7 +86,7 @@ impl<K: Debug, V: Debug, A: AllocRef + Clone> Debug for RustcEntry<'_, K, V, A> 
 /// [`RustcEntry`]: enum.RustcEntry.html
 pub struct RustcOccupiedEntry<'a, K, V, A = Global>
 where
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     key: Option<K>,
     elem: Bucket<(K, V)>,
@@ -97,18 +97,18 @@ unsafe impl<K, V, A> Send for RustcOccupiedEntry<'_, K, V, A>
 where
     K: Send,
     V: Send,
-    A: AllocRef + Clone + Send,
+    A: Allocator + Clone + Send,
 {
 }
 unsafe impl<K, V, A> Sync for RustcOccupiedEntry<'_, K, V, A>
 where
     K: Sync,
     V: Sync,
-    A: AllocRef + Clone + Sync,
+    A: Allocator + Clone + Sync,
 {
 }
 
-impl<K: Debug, V: Debug, A: AllocRef + Clone> Debug for RustcOccupiedEntry<'_, K, V, A> {
+impl<K: Debug, V: Debug, A: Allocator + Clone> Debug for RustcOccupiedEntry<'_, K, V, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("key", self.key())
@@ -123,20 +123,20 @@ impl<K: Debug, V: Debug, A: AllocRef + Clone> Debug for RustcOccupiedEntry<'_, K
 /// [`RustcEntry`]: enum.RustcEntry.html
 pub struct RustcVacantEntry<'a, K, V, A = Global>
 where
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     hash: u64,
     key: K,
     table: &'a mut RawTable<(K, V), A>,
 }
 
-impl<K: Debug, V, A: AllocRef + Clone> Debug for RustcVacantEntry<'_, K, V, A> {
+impl<K: Debug, V, A: Allocator + Clone> Debug for RustcVacantEntry<'_, K, V, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VacantEntry").field(self.key()).finish()
     }
 }
 
-impl<'a, K, V, A: AllocRef + Clone> RustcEntry<'a, K, V, A> {
+impl<'a, K, V, A: Allocator + Clone> RustcEntry<'a, K, V, A> {
     /// Sets the value of the entry, and returns a RustcOccupiedEntry.
     ///
     /// # Examples
@@ -265,7 +265,7 @@ impl<'a, K, V, A: AllocRef + Clone> RustcEntry<'a, K, V, A> {
     }
 }
 
-impl<'a, K, V: Default, A: AllocRef + Clone> RustcEntry<'a, K, V, A> {
+impl<'a, K, V: Default, A: Allocator + Clone> RustcEntry<'a, K, V, A> {
     /// Ensures a value is in the entry by inserting the default value if empty,
     /// and returns a mutable reference to the value in the entry.
     ///
@@ -293,7 +293,7 @@ impl<'a, K, V: Default, A: AllocRef + Clone> RustcEntry<'a, K, V, A> {
     }
 }
 
-impl<'a, K, V, A: AllocRef + Clone> RustcOccupiedEntry<'a, K, V, A> {
+impl<'a, K, V, A: Allocator + Clone> RustcOccupiedEntry<'a, K, V, A> {
     /// Gets a reference to the key in the entry.
     ///
     /// # Examples
@@ -520,7 +520,7 @@ impl<'a, K, V, A: AllocRef + Clone> RustcOccupiedEntry<'a, K, V, A> {
     }
 }
 
-impl<'a, K, V, A: AllocRef + Clone> RustcVacantEntry<'a, K, V, A> {
+impl<'a, K, V, A: Allocator + Clone> RustcVacantEntry<'a, K, V, A> {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `RustcVacantEntry`.
     ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -8,7 +8,7 @@ use core::mem;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
 
 use super::map::{self, ConsumeAllOnDrop, DefaultHashBuilder, DrainFilterInner, HashMap, Keys};
-use crate::raw::{AllocRef, Global};
+use crate::raw::{Allocator, Global};
 
 // Future Optimization (FIXME!)
 // =============================
@@ -112,7 +112,7 @@ use crate::raw::{AllocRef, Global};
 /// [`HashMap`]: struct.HashMap.html
 /// [`PartialEq`]: https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
 /// [`RefCell`]: https://doc.rust-lang.org/std/cell/struct.RefCell.html
-pub struct HashSet<T, S = DefaultHashBuilder, A: AllocRef + Clone = Global> {
+pub struct HashSet<T, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
     pub(crate) map: HashMap<T, (), S, A>,
 }
 
@@ -169,7 +169,7 @@ impl<T> HashSet<T, DefaultHashBuilder> {
 }
 
 #[cfg(feature = "ahash")]
-impl<T: Hash + Eq, A: AllocRef + Clone> HashSet<T, DefaultHashBuilder, A> {
+impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     /// Creates an empty `HashSet`.
     ///
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
@@ -208,7 +208,7 @@ impl<T: Hash + Eq, A: AllocRef + Clone> HashSet<T, DefaultHashBuilder, A> {
     }
 }
 
-impl<T, S, A: AllocRef + Clone> HashSet<T, S, A> {
+impl<T, S, A: Allocator + Clone> HashSet<T, S, A> {
     /// Returns the number of elements the set can hold without reallocating.
     ///
     /// # Examples
@@ -454,7 +454,7 @@ impl<T, S, A> HashSet<T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
@@ -535,7 +535,7 @@ impl<T, S, A> HashSet<T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     /// Reserves capacity for at least `additional` more elements to be inserted
     /// in the `HashSet`. The collection may reserve more space to avoid
@@ -1077,7 +1077,7 @@ impl<T, S, A> PartialEq for HashSet<T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
@@ -1092,7 +1092,7 @@ impl<T, S, A> Eq for HashSet<T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
 }
 
@@ -1100,7 +1100,7 @@ impl<T, S, A> fmt::Debug for HashSet<T, S, A>
 where
     T: Eq + Hash + fmt::Debug,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
@@ -1111,7 +1111,7 @@ impl<T, S, A> FromIterator<T> for HashSet<T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher + Default,
-    A: Default + AllocRef + Clone,
+    A: Default + Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
@@ -1125,7 +1125,7 @@ impl<T, S, A> Extend<T> for HashSet<T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
@@ -1149,7 +1149,7 @@ impl<'a, T, S, A> Extend<&'a T> for HashSet<T, S, A>
 where
     T: 'a + Eq + Hash + Copy,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
@@ -1172,7 +1172,7 @@ where
 impl<T, S, A> Default for HashSet<T, S, A>
 where
     S: Default,
-    A: Default + AllocRef + Clone,
+    A: Default + Allocator + Clone,
 {
     /// Creates an empty `HashSet<T, S>` with the `Default` value for the hasher.
     #[cfg_attr(feature = "inline-more", inline)]
@@ -1187,7 +1187,7 @@ impl<T, S, A> BitOr<&HashSet<T, S, A>> for &HashSet<T, S, A>
 where
     T: Eq + Hash + Clone,
     S: BuildHasher + Default,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Output = HashSet<T, S>;
 
@@ -1220,7 +1220,7 @@ impl<T, S, A> BitAnd<&HashSet<T, S, A>> for &HashSet<T, S, A>
 where
     T: Eq + Hash + Clone,
     S: BuildHasher + Default,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Output = HashSet<T, S>;
 
@@ -1331,7 +1331,7 @@ pub struct Iter<'a, K> {
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`into_iter`]: struct.HashSet.html#method.into_iter
-pub struct IntoIter<K, A: AllocRef + Clone = Global> {
+pub struct IntoIter<K, A: Allocator + Clone = Global> {
     iter: map::IntoIter<K, (), A>,
 }
 
@@ -1342,7 +1342,7 @@ pub struct IntoIter<K, A: AllocRef + Clone = Global> {
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`drain`]: struct.HashSet.html#method.drain
-pub struct Drain<'a, K, A: AllocRef + Clone = Global> {
+pub struct Drain<'a, K, A: Allocator + Clone = Global> {
     iter: map::Drain<'a, K, (), A>,
 }
 
@@ -1353,7 +1353,7 @@ pub struct Drain<'a, K, A: AllocRef + Clone = Global> {
 ///
 /// [`drain_filter`]: struct.HashSet.html#method.drain_filter
 /// [`HashSet`]: struct.HashSet.html
-pub struct DrainFilter<'a, K, F, A: AllocRef + Clone = Global>
+pub struct DrainFilter<'a, K, F, A: Allocator + Clone = Global>
 where
     F: FnMut(&K) -> bool,
 {
@@ -1368,7 +1368,7 @@ where
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`intersection`]: struct.HashSet.html#method.intersection
-pub struct Intersection<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct Intersection<'a, T, S, A: Allocator + Clone = Global> {
     // iterator of the first set
     iter: Iter<'a, T>,
     // the second set
@@ -1382,7 +1382,7 @@ pub struct Intersection<'a, T, S, A: AllocRef + Clone = Global> {
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`difference`]: struct.HashSet.html#method.difference
-pub struct Difference<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct Difference<'a, T, S, A: Allocator + Clone = Global> {
     // iterator of the first set
     iter: Iter<'a, T>,
     // the second set
@@ -1396,7 +1396,7 @@ pub struct Difference<'a, T, S, A: AllocRef + Clone = Global> {
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`symmetric_difference`]: struct.HashSet.html#method.symmetric_difference
-pub struct SymmetricDifference<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct SymmetricDifference<'a, T, S, A: Allocator + Clone = Global> {
     iter: Chain<Difference<'a, T, S, A>, Difference<'a, T, S, A>>,
 }
 
@@ -1407,11 +1407,11 @@ pub struct SymmetricDifference<'a, T, S, A: AllocRef + Clone = Global> {
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`union`]: struct.HashSet.html#method.union
-pub struct Union<'a, T, S, A: AllocRef + Clone = Global> {
+pub struct Union<'a, T, S, A: Allocator + Clone = Global> {
     iter: Chain<Iter<'a, T>, Difference<'a, T, S, A>>,
 }
 
-impl<'a, T, S, A: AllocRef + Clone> IntoIterator for &'a HashSet<T, S, A> {
+impl<'a, T, S, A: Allocator + Clone> IntoIterator for &'a HashSet<T, S, A> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
@@ -1421,7 +1421,7 @@ impl<'a, T, S, A: AllocRef + Clone> IntoIterator for &'a HashSet<T, S, A> {
     }
 }
 
-impl<T, S, A: AllocRef + Clone> IntoIterator for HashSet<T, S, A> {
+impl<T, S, A: Allocator + Clone> IntoIterator for HashSet<T, S, A> {
     type Item = T;
     type IntoIter = IntoIter<T, A>;
 
@@ -1487,7 +1487,7 @@ impl<K: fmt::Debug> fmt::Debug for Iter<'_, K> {
     }
 }
 
-impl<K, A: AllocRef + Clone> Iterator for IntoIter<K, A> {
+impl<K, A: Allocator + Clone> Iterator for IntoIter<K, A> {
     type Item = K;
 
     #[cfg_attr(feature = "inline-more", inline)]
@@ -1503,22 +1503,22 @@ impl<K, A: AllocRef + Clone> Iterator for IntoIter<K, A> {
         self.iter.size_hint()
     }
 }
-impl<K, A: AllocRef + Clone> ExactSizeIterator for IntoIter<K, A> {
+impl<K, A: Allocator + Clone> ExactSizeIterator for IntoIter<K, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
-impl<K, A: AllocRef + Clone> FusedIterator for IntoIter<K, A> {}
+impl<K, A: Allocator + Clone> FusedIterator for IntoIter<K, A> {}
 
-impl<K: fmt::Debug, A: AllocRef + Clone> fmt::Debug for IntoIter<K, A> {
+impl<K: fmt::Debug, A: Allocator + Clone> fmt::Debug for IntoIter<K, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let entries_iter = self.iter.iter().map(|(k, _)| k);
         f.debug_list().entries(entries_iter).finish()
     }
 }
 
-impl<K, A: AllocRef + Clone> Iterator for Drain<'_, K, A> {
+impl<K, A: Allocator + Clone> Iterator for Drain<'_, K, A> {
     type Item = K;
 
     #[cfg_attr(feature = "inline-more", inline)]
@@ -1534,22 +1534,22 @@ impl<K, A: AllocRef + Clone> Iterator for Drain<'_, K, A> {
         self.iter.size_hint()
     }
 }
-impl<K, A: AllocRef + Clone> ExactSizeIterator for Drain<'_, K, A> {
+impl<K, A: Allocator + Clone> ExactSizeIterator for Drain<'_, K, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
-impl<K, A: AllocRef + Clone> FusedIterator for Drain<'_, K, A> {}
+impl<K, A: Allocator + Clone> FusedIterator for Drain<'_, K, A> {}
 
-impl<K: fmt::Debug, A: AllocRef + Clone> fmt::Debug for Drain<'_, K, A> {
+impl<K: fmt::Debug, A: Allocator + Clone> fmt::Debug for Drain<'_, K, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let entries_iter = self.iter.iter().map(|(k, _)| k);
         f.debug_list().entries(entries_iter).finish()
     }
 }
 
-impl<'a, K, F, A: AllocRef + Clone> Drop for DrainFilter<'a, K, F, A>
+impl<'a, K, F, A: Allocator + Clone> Drop for DrainFilter<'a, K, F, A>
 where
     F: FnMut(&K) -> bool,
 {
@@ -1563,7 +1563,7 @@ where
     }
 }
 
-impl<K, F, A: AllocRef + Clone> Iterator for DrainFilter<'_, K, F, A>
+impl<K, F, A: Allocator + Clone> Iterator for DrainFilter<'_, K, F, A>
 where
     F: FnMut(&K) -> bool,
 {
@@ -1582,10 +1582,12 @@ where
     }
 }
 
-impl<K, F, A: AllocRef + Clone> FusedIterator for DrainFilter<'_, K, F, A> where F: FnMut(&K) -> bool
-{}
+impl<K, F, A: Allocator + Clone> FusedIterator for DrainFilter<'_, K, F, A> where
+    F: FnMut(&K) -> bool
+{
+}
 
-impl<T, S, A: AllocRef + Clone> Clone for Intersection<'_, T, S, A> {
+impl<T, S, A: Allocator + Clone> Clone for Intersection<'_, T, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         Intersection {
@@ -1599,7 +1601,7 @@ impl<'a, T, S, A> Iterator for Intersection<'a, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Item = &'a T;
 
@@ -1624,7 +1626,7 @@ impl<T, S, A> fmt::Debug for Intersection<'_, T, S, A>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
@@ -1635,11 +1637,11 @@ impl<T, S, A> FusedIterator for Intersection<'_, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
 }
 
-impl<T, S, A: AllocRef + Clone> Clone for Difference<'_, T, S, A> {
+impl<T, S, A: Allocator + Clone> Clone for Difference<'_, T, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         Difference {
@@ -1653,7 +1655,7 @@ impl<'a, T, S, A> Iterator for Difference<'a, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Item = &'a T;
 
@@ -1678,7 +1680,7 @@ impl<T, S, A> FusedIterator for Difference<'_, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
 }
 
@@ -1686,14 +1688,14 @@ impl<T, S, A> fmt::Debug for Difference<'_, T, S, A>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
-impl<T, S, A: AllocRef + Clone> Clone for SymmetricDifference<'_, T, S, A> {
+impl<T, S, A: Allocator + Clone> Clone for SymmetricDifference<'_, T, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         SymmetricDifference {
@@ -1706,7 +1708,7 @@ impl<'a, T, S, A> Iterator for SymmetricDifference<'a, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Item = &'a T;
 
@@ -1724,7 +1726,7 @@ impl<T, S, A> FusedIterator for SymmetricDifference<'_, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
 }
 
@@ -1732,14 +1734,14 @@ impl<T, S, A> fmt::Debug for SymmetricDifference<'_, T, S, A>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
-impl<T, S, A: AllocRef + Clone> Clone for Union<'_, T, S, A> {
+impl<T, S, A: Allocator + Clone> Clone for Union<'_, T, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         Union {
@@ -1752,7 +1754,7 @@ impl<T, S, A> FusedIterator for Union<'_, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
 }
 
@@ -1760,7 +1762,7 @@ impl<T, S, A> fmt::Debug for Union<'_, T, S, A>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
@@ -1771,7 +1773,7 @@ impl<'a, T, S, A> Iterator for Union<'a, T, S, A>
 where
     T: Eq + Hash,
     S: BuildHasher,
-    A: AllocRef + Clone,
+    A: Allocator + Clone,
 {
     type Item = &'a T;
 
@@ -1793,32 +1795,32 @@ fn assert_covariance() {
     fn iter<'a, 'new>(v: Iter<'a, &'static str>) -> Iter<'a, &'new str> {
         v
     }
-    fn into_iter<'new, A: AllocRef + Clone>(
+    fn into_iter<'new, A: Allocator + Clone>(
         v: IntoIter<&'static str, A>,
     ) -> IntoIter<&'new str, A> {
         v
     }
-    fn difference<'a, 'new, A: AllocRef + Clone>(
+    fn difference<'a, 'new, A: Allocator + Clone>(
         v: Difference<'a, &'static str, DefaultHashBuilder, A>,
     ) -> Difference<'a, &'new str, DefaultHashBuilder, A> {
         v
     }
-    fn symmetric_difference<'a, 'new, A: AllocRef + Clone>(
+    fn symmetric_difference<'a, 'new, A: Allocator + Clone>(
         v: SymmetricDifference<'a, &'static str, DefaultHashBuilder, A>,
     ) -> SymmetricDifference<'a, &'new str, DefaultHashBuilder, A> {
         v
     }
-    fn intersection<'a, 'new, A: AllocRef + Clone>(
+    fn intersection<'a, 'new, A: Allocator + Clone>(
         v: Intersection<'a, &'static str, DefaultHashBuilder, A>,
     ) -> Intersection<'a, &'new str, DefaultHashBuilder, A> {
         v
     }
-    fn union<'a, 'new, A: AllocRef + Clone>(
+    fn union<'a, 'new, A: Allocator + Clone>(
         v: Union<'a, &'static str, DefaultHashBuilder, A>,
     ) -> Union<'a, &'new str, DefaultHashBuilder, A> {
         v
     }
-    fn drain<'new, A: AllocRef + Clone>(
+    fn drain<'new, A: Allocator + Clone>(
         d: Drain<'static, &'static str, A>,
     ) -> Drain<'new, &'new str, A> {
         d


### PR DESCRIPTION
`AllocRef` was renamed to `Allocator` in https://github.com/rust-lang/rust/pull/79286.