### PR TITLE
note on HashDoS resistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ in environments without `std`, such as embedded systems and kernels.
 
 - Drop-in replacement for the standard library `HashMap` and `HashSet` types.
 - Uses [AHash](https://github.com/tkaitchuck/aHash) as the default hasher, which is much faster than SipHash.
+  However, AHash does *not provide the same level of HashDoS resistance* as SipHash, so if that is important to you, you might want to consider using a different hasher.
 - Around 2x faster than the previous standard library `HashMap`.
 - Lower memory usage: only 1 byte of overhead per entry instead of 8.
 - Compatible with `#[no_std]` (but requires a global allocator with the `alloc` crate).


### PR DESCRIPTION
Looks like the comment I added in https://github.com/rust-lang/hashbrown/pull/111 was removed in https://github.com/rust-lang/hashbrown/pull/207.

I appreciate that aHash [makes an effort](https://github.com/tkaitchuck/aHash/wiki/How-aHash-is-resists-DOS-attacks) of providing some protection against HashDoS, but in cryptography, this alone is not enough. In particular, it doesn't use full AES (unless that has changed since its inception), so no cryptographic claims can be made about the quality of the involved cipher. The wiki page I linked is somewhat misleading in this regard I think -- yes, doing a few rounds of AES does mangle the data quite a bit, but not in any way that I would place a bet on. In use for cryptography, using not enough AES rounds the way aHash does *is* known to lead to an easily breakable cipher. Just because there's "AES" in the name and a naive differential analysis fails doesn't mean it's secure.

Just using a key in *some* way is not sufficient to claim HashDoS resistance. You also need to show that there is no way to leak the key, e.g. through a timing side-channel. So given that this can be security-critical, I think we should follow the usual standards of waiting for independent analysis and confirmation of the given claims by other experts before accepting them.

The wiki page also claims it to be an "advantage" that there is no fixed standard. That is a rather questionable claim, given that all the most secure ciphers we use daily on the internet *do* have a fixed standard, and precisely following the standard is crucial for security.