### PR TITLE
Imported new documentation for .or_insert_with_key

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2556,9 +2556,12 @@ impl<'a, K, V, S, A: AllocRef + Clone> Entry<'a, K, V, S, A> {
         }
     }
 
-    /// Ensures a value is in the entry by inserting, if empty, the result of the default function,
-    /// which takes the key as its argument, and returns a mutable reference to the value in the
-    /// entry.
+    /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    /// This method allows for generating key-derived values for insertion by providing the default
+    /// function a reference to the key that was moved during the `.entry(key)` method call.
+    ///
+    /// The reference to the moved key is provided so that cloning or copying the key is
+    /// unnecessary, unlike with `.or_insert_with(|| ... )`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
`HashMap` and `BTreeMap` in `std` have better documentation now (https://github.com/rust-lang/rust/pull/78083/commits/f1b930d57cd9014a4e97c2b0ac366c8fa51f38c7) for the `entry.or_insert_with_key(...)` method. This copies the documentation to `hashbrown`.