### PR TITLE
Expose non-nightly raw::Allocator trait's required error type, AllocError

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -32,7 +32,7 @@ cfg_if! {
 }
 
 mod alloc;
-pub use self::alloc::{do_alloc, Allocator, Global};
+pub use self::alloc::{do_alloc, AllocError, Allocator, Global};
 
 mod bitmask;
 


### PR DESCRIPTION
This patch exposes the `hashbrown::raw::inner::alloc::inner::AllocError` struct type to the public raw module (i.e. as `hashbrown::raw::AllocError`). This is needed to be able to implement the non-nightly-specific `hashbrown::raw::Allocator` trait since its `allocate` method's return type uses the struct:

```rust
    pub unsafe trait Allocator {
        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError>;
        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
    }
```

This appears to have been a minor omission in the public-facing module as the only `hashbrown::raw::Allocator` implementation, `hashbrown::raw::Global`, is in the same module.