### PR TITLE
Export AllocError as well as Allocator.

### DIFF
--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -3,7 +3,7 @@ pub use self::inner::*;
 #[cfg(feature = "nightly")]
 mod inner {
     use crate::alloc::alloc::Layout;
-    pub use crate::alloc::alloc::{Allocator, Global};
+    pub use crate::alloc::alloc::{AllocError, Allocator, Global};
     use core::ptr::NonNull;
 
     #[allow(clippy::map_err_ignore)]

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -32,7 +32,7 @@ cfg_if! {
 }
 
 mod alloc;
-pub use self::alloc::{do_alloc, Allocator, Global};
+pub use self::alloc::{do_alloc, AllocError, Allocator, Global};
 
 mod bitmask;
 


### PR DESCRIPTION
This PR re-exports the `AllocError` type alongside `Allocator` and others from the `raw` submodule.

This seems to be necessary to implement the `Allocator` trait from outside the crate (and I want to use exported types from this crate so that I don't have to depend on the unstable allocator API directly). It allowed me to instantiate hashbrown hashmaps using `bumpalo` over in bytecodealliance/regalloc.rs#115; I couldn't work out another way to do this. If there is a more direct way, please do let me know! (Thanks for this excellent crate and the configurable allocator interface, in any case!)