### PR TITLE
Hide allocator details and default to Global

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1611,7 +1611,7 @@ pub struct RawEntryBuilderMut<'a, K, V, S, A: Allocator + Clone = Global> {
 /// [`Entry`]: enum.Entry.html
 /// [`raw_entry_mut`]: struct.HashMap.html#method.raw_entry_mut
 /// [`RawEntryBuilderMut`]: struct.RawEntryBuilderMut.html
-pub enum RawEntryMut<'a, K, V, S, A: Allocator + Clone> {
+pub enum RawEntryMut<'a, K, V, S, A: Allocator + Clone = Global> {
     /// An occupied entry.
     Occupied(RawOccupiedEntryMut<'a, K, V, S, A>),
     /// A vacant entry.
@@ -2186,7 +2186,7 @@ impl<K, V, S, A: Allocator + Clone> Debug for RawEntryBuilder<'_, K, V, S, A> {
 ///
 /// [`HashMap`]: struct.HashMap.html
 /// [`entry`]: struct.HashMap.html#method.entry
-pub enum Entry<'a, K, V, S, A>
+pub enum Entry<'a, K, V, S, A = Global>
 where
     A: Allocator + Clone,
 {

--- a/src/map.rs
+++ b/src/map.rs
@@ -405,7 +405,7 @@ impl<K, V, S> HashMap<K, V, S> {
     pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
         Self {
             hash_builder,
-            table: RawTable::with_capacity(Global, capacity),
+            table: RawTable::with_capacity(capacity),
         }
     }
 }
@@ -464,7 +464,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     pub fn with_capacity_and_hasher_in(capacity: usize, hash_builder: S, alloc: A) -> Self {
         Self {
             hash_builder,
-            table: RawTable::with_capacity(alloc, capacity),
+            table: RawTable::with_capacity_in(capacity, alloc),
         }
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1428,7 +1428,7 @@ impl<K, V, A: Allocator + Clone> IntoIter<K, V, A> {
 ///
 /// [`keys`]: struct.HashMap.html#method.keys
 /// [`HashMap`]: struct.HashMap.html
-pub struct Keys<'a, K, V = Global> {
+pub struct Keys<'a, K, V> {
     inner: Iter<'a, K, V>,
 }
 

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -1,9 +1,9 @@
-pub use self::inner::*;
+pub(crate) use self::inner::{do_alloc, Allocator, Global};
 
 #[cfg(feature = "nightly")]
 mod inner {
     use crate::alloc::alloc::Layout;
-    pub use crate::alloc::alloc::{AllocError, Allocator, Global};
+    pub use crate::alloc::alloc::{Allocator, Global};
     use core::ptr::NonNull;
 
     #[allow(clippy::map_err_ignore)]

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -367,7 +367,7 @@ impl<T> Bucket<T> {
 }
 
 /// A raw hash table with an unsafe API.
-pub struct RawTable<T, A: Allocator + Clone> {
+pub struct RawTable<T, A: Allocator + Clone = Global> {
     // Mask to get an index from a hash value. The value is one less than the
     // number of buckets in the table.
     bucket_mask: usize,
@@ -1770,7 +1770,7 @@ impl<T> ExactSizeIterator for RawIter<T> {}
 impl<T> FusedIterator for RawIter<T> {}
 
 /// Iterator which consumes a table and returns elements.
-pub struct RawIntoIter<T, A: Allocator + Clone> {
+pub struct RawIntoIter<T, A: Allocator + Clone = Global> {
     iter: RawIter<T>,
     allocation: Option<(NonNull<u8>, Layout)>,
     marker: PhantomData<T>,
@@ -1845,7 +1845,7 @@ impl<T, A: Allocator + Clone> ExactSizeIterator for RawIntoIter<T, A> {}
 impl<T, A: Allocator + Clone> FusedIterator for RawIntoIter<T, A> {}
 
 /// Iterator which consumes elements without freeing the table storage.
-pub struct RawDrain<'a, T, A: Allocator + Clone> {
+pub struct RawDrain<'a, T, A: Allocator + Clone = Global> {
     iter: RawIter<T>,
 
     // The table is moved into the iterator for the duration of the drain. This
@@ -1915,7 +1915,7 @@ impl<T, A: Allocator + Clone> FusedIterator for RawDrain<'_, T, A> {}
 /// Iterator over occupied buckets that could match a given hash.
 ///
 /// In rare cases, the iterator may return a bucket with a different hash.
-pub struct RawIterHash<'a, T, A: Allocator + Clone> {
+pub struct RawIterHash<'a, T, A: Allocator + Clone = Global> {
     table: &'a RawTable<T, A>,
 
     // The top 7 bits of the hash.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -32,7 +32,7 @@ cfg_if! {
 }
 
 mod alloc;
-pub use self::alloc::{do_alloc, AllocError, Allocator, Global};
+pub(crate) use self::alloc::{do_alloc, Allocator, Global};
 
 mod bitmask;
 


### PR DESCRIPTION
**This is a breaking change!**

We no longer re-export the unstable allocator items from the standard library, nor the stable shims approximating the same. The choice was predicated on the "nightly" feature, but crates that did not set that feature could be forced into it by others in the dependency tree, and then fail for lack of `#![feature(allocator_api)]` when referencing these items. All types have been audited to have a default `A=Global` to make sure the type doesn't need to be named for stable users. Fixes #226.

Many of the parallel iterators don't need the `S` hasher or `A` allocator at all if they convert to a tighter inner type upon construction. This has been cleaned up, and those that do still need `A` now default to `A=Global`.

`RawTable::with_capacity` and `try_with_capacity` have moved back to being methods for `Global` only. New `with_capacity_in` and `try_with_capacity_in` methods allow custom allocators, with the `alloc` parameter last to match the similar methods on `HashMap` and `HashSet`.