### PR TITLE
Add `try_insert_no_grow` method on `RawTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Added
+- Added safe `try_insert_no_grow` method to `RawTable`. (#229)
+
 ## Changed
 - The minimum Rust version has been bumped to 1.49.0. (#230)
 


### PR DESCRIPTION
This is my attempt to answer the need described in #224 by adding a method on `RawTable`:

```rust
impl<T> RawTable<T, Global> {
    pub fn try_insert_no_grow(&mut self, hash: u64, value: T) -> Result<Bucket<T>, T>;
}
```

This method follows the logic of `RawTable::insert`, but if the table would need to grow to accomodate the new element it "signals" by returning `Err(value)` instead of performing the reallocation and insertion.

Marked as draft for now because

- I'm not sure whether there's a better way to achieve this (advice welcome)
- some tests are probably needed
- there's an unused warning (despite the `pub`) that I haven't figured out how to get rid of