### PR TITLE
Apply suggestions from `clippy::ptr_as_ptr`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
     - name: "x86_64-unknown-linux-gnu (stable)"
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
-    - name: "x86_64-unknown-linux-gnu (Rust 1.36.0)"
-      rust: 1.36.0
+    - name: "x86_64-unknown-linux-gnu (Rust 1.49.0)"
+      rust: 1.49.0
       env: TARGET=x86_64-unknown-linux-gnu
     - name: "i686-unknown-linux-gnu"
       env: TARGET=i686-unknown-linux-gnu CROSS=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Changed
+- The minimum Rust version has been bumped to 1.49.0. (#230)
+
 ## [v0.10.0] - 2021-01-16
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hashbrown
 [![Build Status](https://travis-ci.com/rust-lang/hashbrown.svg?branch=master)](https://travis-ci.com/rust-lang/hashbrown)
 [![Crates.io](https://img.shields.io/crates/v/hashbrown.svg)](https://crates.io/crates/hashbrown)
 [![Documentation](https://docs.rs/hashbrown/badge.svg)](https://docs.rs/hashbrown)
-[![Rust](https://img.shields.io/badge/rust-1.36.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
+[![Rust](https://img.shields.io/badge/rust-1.49.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
 
 This crate is a Rust port of Google's high-performance [SwissTable] hash
 map, adapted to make it a drop-in replacement for Rust's standard `HashMap`

--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -67,7 +67,7 @@ impl Group {
     #[inline]
     #[allow(clippy::cast_ptr_alignment)] // unaligned load
     pub unsafe fn load(ptr: *const u8) -> Self {
-        Group(ptr::read_unaligned(ptr as *const _))
+        Group(ptr::read_unaligned(ptr.cast()))
     }
 
     /// Loads a group of bytes starting at the given address, which must be
@@ -77,7 +77,7 @@ impl Group {
     pub unsafe fn load_aligned(ptr: *const u8) -> Self {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        Group(ptr::read(ptr as *const _))
+        Group(ptr::read(ptr.cast()))
     }
 
     /// Stores the group of bytes to the given address, which must be
@@ -87,7 +87,7 @@ impl Group {
     pub unsafe fn store_aligned(self, ptr: *mut u8) {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        ptr::write(ptr as *mut _, self.0);
+        ptr::write(ptr.cast(), self.0);
     }
 
     /// Returns a `BitMask` indicating all bytes in the group which *may*

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -530,7 +530,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// Returns pointer to one past last element of data table.
     #[cfg_attr(feature = "inline-more", inline)]
     pub unsafe fn data_end(&self) -> NonNull<T> {
-        NonNull::new_unchecked(self.ctrl.as_ptr() as *mut T)
+        NonNull::new_unchecked(self.ctrl.as_ptr().cast())
     }
 
     /// Returns pointer to start of data table.

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -46,7 +46,7 @@ impl Group {
     #[inline]
     #[allow(clippy::cast_ptr_alignment)] // unaligned load
     pub unsafe fn load(ptr: *const u8) -> Self {
-        Group(x86::_mm_loadu_si128(ptr as *const _))
+        Group(x86::_mm_loadu_si128(ptr.cast()))
     }
 
     /// Loads a group of bytes starting at the given address, which must be
@@ -56,7 +56,7 @@ impl Group {
     pub unsafe fn load_aligned(ptr: *const u8) -> Self {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        Group(x86::_mm_load_si128(ptr as *const _))
+        Group(x86::_mm_load_si128(ptr.cast()))
     }
 
     /// Stores the group of bytes to the given address, which must be
@@ -66,7 +66,7 @@ impl Group {
     pub unsafe fn store_aligned(self, ptr: *mut u8) {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        x86::_mm_store_si128(ptr as *mut _, self.0);
+        x86::_mm_store_si128(ptr.cast(), self.0);
     }
 
     /// Returns a `BitMask` indicating all bytes in the group which have


### PR DESCRIPTION
This is a new pedantic lint that triggers on pointer casts with `as` that don't change mutability. It was preventing #229 from passing CI.