### PR TITLE
Add support for bumpalo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core
 compiler_builtins = { version = "0.1.2", optional = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
+# Optional support for bumpalo
+bumpalo = { version = "3.5.0", optional = true }
+
 [dev-dependencies]
 lazy_static = "1.4"
 rand = { version = "0.7.3", features = ["small_rng"] }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This crate has the following Cargo features:
 - `raw`: Enables access to the experimental and unsafe `RawTable` API.
 - `inline-more`: Adds inline hints to most functions, improving run-time performance at the cost
   of compilation time. (enabled by default)
+- `bumpalo`: Provides a `BumpWrapper` type which allows `bumpalo` to be used for memory allocation.
 - `ahash`: Compiles with ahash as default hasher. (enabled by default)
 - `ahash-compile-time-rng`: Activates the `compile-time-rng` feature of ahash. For targets with no random number generator
 this pre-generates seeds at compile time and embeds them as constants. See [aHash's documentation](https://github.com/tkaitchuck/aHash#flags) (disabled by default)

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -9,7 +9,7 @@ if [ "${NO_STD}" = "1" ]; then
     FEATURES="rustc-internal-api"
     OP="build"
 else
-    FEATURES="rustc-internal-api,serde,rayon,raw"
+    FEATURES="rustc-internal-api,serde,rayon,raw,bumpalo"
     OP="test"
 fi
 if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,3 +134,12 @@ pub enum TryReserveError {
 #[cfg(feature = "bumpalo")]
 #[derive(Clone, Copy, Debug)]
 pub struct BumpWrapper<'a>(&'a bumpalo::Bump);
+
+#[cfg(feature = "bumpalo")]
+#[test]
+fn test_bumpalo() {
+    use bumpalo::Bump;
+    let bump = Bump::new();
+    let mut map = HashMap::new_in(BumpWrapper(&bump));
+    map.insert(0, 1);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@
         min_specialization,
         extend_one,
         allocator_api,
-        slice_ptr_get
+        slice_ptr_get,
+        nonnull_slice_from_raw_parts
     )
 )]
 #![allow(
@@ -124,3 +125,12 @@ pub enum TryReserveError {
         layout: alloc::alloc::Layout,
     },
 }
+
+/// Wrapper around `Bump` which allows it to be used as an allocator for
+/// `HashMap`, `HashSet` and `RawTable`.
+///
+/// `Bump` can be used directly without this wrapper on nightly if you enable
+/// the `allocator-api` feature of the `bumpalo` crate.
+#[cfg(feature = "bumpalo")]
+#[derive(Clone, Copy, Debug)]
+pub struct BumpWrapper<'a>(&'a bumpalo::Bump);

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -13,6 +13,19 @@ mod inner {
             .map(|ptr| ptr.as_non_null_ptr())
             .map_err(|_| ())
     }
+
+    #[cfg(feature = "bumpalo")]
+    unsafe impl Allocator for crate::BumpWrapper<'_> {
+        #[inline]
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, core::alloc::AllocError> {
+            match self.0.try_alloc_layout(layout) {
+                Ok(ptr) => Ok(NonNull::slice_from_raw_parts(ptr, layout.size())),
+                Err(_) => Err(core::alloc::AllocError),
+            }
+        }
+        #[inline]
+        unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+    }
 }
 
 #[cfg(not(feature = "nightly"))]
@@ -20,31 +33,40 @@ mod inner {
     use crate::alloc::alloc::{alloc, dealloc, Layout};
     use core::ptr::NonNull;
 
-    pub struct AllocError;
-
     pub unsafe trait Allocator {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError>;
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()>;
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
     }
 
     #[derive(Copy, Clone)]
     pub struct Global;
     unsafe impl Allocator for Global {
-        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
-            unsafe { NonNull::new(alloc(layout)).ok_or(AllocError) }
+        #[inline]
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()> {
+            unsafe { NonNull::new(alloc(layout)).ok_or(()) }
         }
+        #[inline]
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             dealloc(ptr.as_ptr(), layout)
         }
     }
     impl Default for Global {
+        #[inline]
         fn default() -> Self {
             Global
         }
     }
 
-    #[allow(clippy::map_err_ignore)]
     pub fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
-        alloc.allocate(layout).map_err(|_| ())
+        alloc.allocate(layout)
+    }
+
+    #[cfg(feature = "bumpalo")]
+    unsafe impl Allocator for crate::BumpWrapper<'_> {
+        #[allow(clippy::map_err_ignore)]
+        fn allocate(&self, layout: Layout) -> Result<NonNull<u8>, ()> {
+            self.0.try_alloc_layout(layout).map_err(|_| ())
+        }
+        unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
     }
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1989,8 +1989,7 @@ impl<T, A: Allocator + Clone> Drop for RawIntoIter<T, A> {
 
             // Free the table
             if let Some((ptr, layout)) = self.allocation {
-                self.alloc
-                    .deallocate(NonNull::new_unchecked(ptr.as_ptr()), layout);
+                self.alloc.deallocate(ptr, layout);
             }
         }
     }


### PR DESCRIPTION
Allows `Bump` and `&Bump` to be used as allocators without the nightly feature.

This is currently blocked on https://github.com/fitzgen/bumpalo/pull/92 for support on nightly.