### PR TITLE
Issue #225: Specialization fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.6.1", default-features = false, optional = true, path="../../aHash" }
+ahash = { version = "0.7.0", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.6.1", default-features = false, optional = true }
+ahash = { version = "0.6.1", default-features = false, optional = true, path="../../aHash" }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }

--- a/src/map.rs
+++ b/src/map.rs
@@ -211,7 +211,7 @@ impl<K: Clone, V: Clone, S: Clone> Clone for HashMap<K, V, S> {
 #[cfg_attr(feature = "inline-more", inline)]
 pub(crate) fn make_hasher<K, Q, V, S>(hash_builder: &S) -> impl Fn(&(Q, V)) -> u64 + '_
 where
-    K: Borrow<Q>,
+    K: Borrow<Q> + Hash,
     Q: Hash,
     S: BuildHasher,
 {
@@ -243,7 +243,7 @@ where
 #[cfg_attr(feature = "inline-more", inline)]
 pub(crate) fn make_hash<K, Q, S>(hash_builder: &S, val: &Q) -> u64
 where
-    K: Borrow<Q>,
+    K: Borrow<Q> + Hash,
     Q: Hash + ?Sized,
     S: BuildHasher,
 {
@@ -251,8 +251,7 @@ where
     {
         //This enables specialization to improve performance on primitive types
         use ahash::CallHasher;
-        let state = hash_builder.build_hasher();
-        Q::get_hash(val, state)
+        K::get_hash(val, hash_builder)
     }
     #[cfg(not(feature = "ahash"))]
     {
@@ -273,8 +272,7 @@ where
     {
         //This enables specialization to improve performance on primitive types
         use ahash::CallHasher;
-        let state = hash_builder.build_hasher();
-        K::get_hash(val, state)
+        K::get_hash(val, hash_builder)
     }
     #[cfg(not(feature = "ahash"))]
     {
@@ -1668,7 +1666,7 @@ impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
     pub fn from_key<Q: ?Sized>(self, k: &Q) -> RawEntryMut<'a, K, V, S, A>
     where
         S: BuildHasher,
-        K: Borrow<Q>,
+        K: Borrow<Q> + Hash,
         Q: Hash + Eq,
     {
         let hash = make_hash::<K, Q, S>(&self.map.hash_builder, k);
@@ -1724,7 +1722,7 @@ impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilder<'a, K, V, S, A> {
     pub fn from_key<Q: ?Sized>(self, k: &Q) -> Option<(&'a K, &'a V)>
     where
         S: BuildHasher,
-        K: Borrow<Q>,
+        K: Borrow<Q> + Hash,
         Q: Hash + Eq,
     {
         let hash = make_hash::<K, Q, S>(&self.map.hash_builder, k);

--- a/src/set.rs
+++ b/src/set.rs
@@ -2250,4 +2250,30 @@ mod test_set {
         set.insert(19);
         assert!(set.contains(&19));
     }
+
+    #[test]
+    fn test_contains_specialization() {
+        use std::boxed::Box;
+        use crate::map::make_insert_hash;
+        use crate::map::make_hash;
+        use crate::std::borrow::ToOwned;
+        use std::string::String;
+
+        let mut m = HashSet::<String>::new();
+        m.insert("hello".to_owned());
+        assert!(m.contains("hello"));
+
+        let mut m = HashSet::<Box<[u8]>>::new();
+
+        let k: Box<[u8]> = Box::from(&b"hello"[..]);
+        let insert_hash = make_insert_hash(m.hasher(), &k);
+
+        let k = &b"hello"[..];
+        let hash = make_hash::<Box<[u8]>,_,_>(m.hasher(), k);
+        assert_eq!(hash, insert_hash);
+
+        m.insert(Box::from(&b"hello"[..]));
+        assert!(m.contains(&b"hello"[..]));
+    }
+
 }


### PR DESCRIPTION
This fixes #225
It uses the key type as the type specialization even when lookup occurs with a different type.