### PR TITLE
test: Add a test for rehash_in_place

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@ extern crate test;
 use test::{black_box, Bencher};
 
 use hashbrown::hash_map::DefaultHashBuilder;
-use hashbrown::HashMap;
+use hashbrown::{HashMap, HashSet};
 use std::{
     collections::hash_map::RandomState,
     sync::atomic::{self, AtomicUsize},
@@ -302,4 +302,30 @@ fn clone_from_large(b: &mut Bencher) {
         m2.clone_from(&m);
         black_box(&mut m2);
     })
+}
+
+#[bench]
+fn rehash_in_place(b: &mut Bencher) {
+    b.iter(|| {
+        let mut set = HashSet::new();
+
+        // Each loop triggers one rehash
+        for _ in 0..10 {
+            for i in 0..224 {
+                set.insert(i);
+            }
+
+            assert_eq!(
+                set.capacity(),
+                224,
+                "The set must be at or close to capacity to trigger a re hashing"
+            );
+
+            for i in 100..1400 {
+                set.remove(&(i - 100));
+                set.insert(i);
+            }
+            set.clear();
+        }
+    });
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -2161,3 +2161,33 @@ impl<'a, A: Allocator + Clone> Iterator for RawIterHashInner<'a, A> {
         }
     }
 }
+
+#[cfg(test)]
+mod test_map {
+    use super::*;
+
+    #[test]
+    fn rehash() {
+        let mut table = RawTable::new();
+        let hasher = |i: &u64| *i;
+        for i in 0..100 {
+            table.insert(i, i, hasher);
+        }
+
+        for i in 0..100 {
+            unsafe {
+                assert_eq!(table.find(i, |x| *x == i).map(|b| b.read()), Some(i));
+            }
+            assert!(table.find(i + 100, |x| *x == i + 100).is_none());
+        }
+
+        table.rehash_in_place(hasher);
+
+        for i in 0..100 {
+            unsafe {
+                assert_eq!(table.find(i, |x| *x == i).map(|b| b.read()), Some(i));
+            }
+            assert!(table.find(i + 100, |x| *x == i + 100).is_none());
+        }
+    }
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -2250,4 +2250,24 @@ mod test_set {
         set.insert(19);
         assert!(set.contains(&19));
     }
+
+    #[test]
+    fn rehash_in_place() {
+        let mut set = HashSet::new();
+
+        for i in 0..224 {
+            set.insert(i);
+        }
+
+        assert_eq!(
+            set.capacity(),
+            224,
+            "The set must be at or close to capacity to trigger a re hashing"
+        );
+
+        for i in 100..1400 {
+            set.remove(&(i - 100));
+            set.insert(i);
+        }
+    }
 }


### PR DESCRIPTION
No tests ran the `rehash_in_place` method before and I could not come up with a way to trigger the rehash from the higher level structures so explicitly calling the method is the best I could do.