### PR TITLE
Implement `Default` for `RawTable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Added
 - Added safe `try_insert_no_grow` method to `RawTable`. (#229)
+- Implemented `Default` for `RawTable`. (#237)
 
 ## Changed
 - The minimum Rust version has been bumped to 1.49.0. (#230)

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1587,6 +1587,13 @@ impl<T: Clone, A: Allocator + Clone> RawTable<T, A> {
     }
 }
 
+impl<T, A: Allocator + Clone + Default> Default for RawTable<T, A> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self::new_in(Default::default())
+    }
+}
+
 #[cfg(feature = "nightly")]
 unsafe impl<#[may_dangle] T, A: Allocator + Clone> Drop for RawTable<T, A> {
     #[cfg_attr(feature = "inline-more", inline)]


### PR DESCRIPTION
This seems straightforward and useful. (I found myself wanting it so I could use `core::mem::take` on a `RawTable` field.) Hopefully I'm not missing something.