### PR TITLE
Add `get_each_mut` methods on `RawTable` and `HashMap`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,8 @@
         extend_one,
         allocator_api,
         slice_ptr_get,
-        nonnull_slice_from_raw_parts
+        nonnull_slice_from_raw_parts,
+        maybe_uninit_array_assume_init
     )
 )]
 #![allow(
@@ -124,6 +125,20 @@ pub enum TryReserveError {
         /// The layout of the allocation request that failed.
         layout: alloc::alloc::Layout,
     },
+}
+
+/// The error type for [`RawTable::get_each_mut`](crate::raw::RawTable::get_each_mut),
+/// [`HashMap::get_each_mut`], and [`HashMap::get_each_key_value_mut`].
+#[cfg(feature = "nightly")]
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum UnavailableMutError {
+    /// The requested entry is not present in the table.
+    Absent,
+    /// The requested entry is present, but a mutable reference to it was already created and
+    /// returned from this call to `get_each_mut` or `get_each_key_value_mut`.
+    ///
+    /// Includes the index of the existing mutable reference in the returned array.
+    Duplicate(usize),
 }
 
 /// Wrapper around `Bump` which allows it to be used as an allocator for


### PR DESCRIPTION
This PR adds a new method `get_each_mut` on `RawTable` and new methods `get_each_mut` and `get_each_key_value_mut` on `HashTable`. These methods enable looking up mutable references to several table or map entries at once. They take advantage of min_const_generics, which is available without a feature gate on recent nightly (but not stable) compilers. Hence everything is behind `#[cfg(feature = "nightly")]` for now.

Closes #151 (cc @HeroicKatora).