### PR TITLE
always inline `ScopeGuard::drop`

### DIFF
--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -42,7 +42,7 @@ impl<T, F> Drop for ScopeGuard<T, F>
 where
     F: FnMut(&mut T),
 {
-    #[cfg_attr(feature = "inline-more", inline)]
+    #[inline]
     fn drop(&mut self) {
         (self.dropfn)(&mut self.value)
     }

--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -9,7 +9,7 @@ where
     value: T,
 }
 
-#[cfg_attr(feature = "inline-more", inline)]
+#[inline]
 pub fn guard<T, F>(value: T, dropfn: F) -> ScopeGuard<T, F>
 where
     F: FnMut(&mut T),
@@ -22,7 +22,7 @@ where
     F: FnMut(&mut T),
 {
     type Target = T;
-    #[cfg_attr(feature = "inline-more", inline)]
+    #[inline]
     fn deref(&self) -> &T {
         &self.value
     }
@@ -32,7 +32,7 @@ impl<T, F> DerefMut for ScopeGuard<T, F>
 where
     F: FnMut(&mut T),
 {
-    #[cfg_attr(feature = "inline-more", inline)]
+    #[inline]
     fn deref_mut(&mut self) -> &mut T {
         &mut self.value
     }


### PR DESCRIPTION
I accidentally discovered that some minor changes in a production project will cause a lot of size increase and some performance regression. After comparison, I found a lot of `ScopeGuard::drop` symbols appeared in the poorer version.

I suspect this is because the compiler missed some inline. for `ScopeGuard`, it should always be beneficial to inline it.