### PR TITLE
Delete bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,0 @@
-status = [
-  "continuous-integration/travis-ci/push",
-]


### PR DESCRIPTION
Since hashbrown is using homu now, this file is unused.