### PR TITLE
Allow clippy::manual_map

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@
     clippy::module_name_repetitions,
     clippy::must_use_candidate,
     clippy::option_if_let_else,
-    clippy::redundant_else
+    clippy::redundant_else,
+    clippy::manual_map
 )]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]


### PR DESCRIPTION
We manually expand these to reduce the amount of LLVM IR generated. (#183)