### PR TITLE
Remove aHash specialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.6.1", default-features = false, optional = true }
+ahash = { version = "0.7.0", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }

--- a/src/map.rs
+++ b/src/map.rs
@@ -251,20 +251,10 @@ where
     Q: Hash + ?Sized,
     S: BuildHasher,
 {
-    #[cfg(feature = "ahash")]
-    {
-        //This enables specialization to improve performance on primitive types
-        use ahash::CallHasher;
-        let state = hash_builder.build_hasher();
-        Q::get_hash(val, state)
-    }
-    #[cfg(not(feature = "ahash"))]
-    {
-        use core::hash::Hasher;
-        let mut state = hash_builder.build_hasher();
-        val.hash(&mut state);
-        state.finish()
-    }
+    use core::hash::Hasher;
+    let mut state = hash_builder.build_hasher();
+    val.hash(&mut state);
+    state.finish()
 }
 
 #[cfg_attr(feature = "inline-more", inline)]
@@ -273,20 +263,10 @@ where
     K: Hash,
     S: BuildHasher,
 {
-    #[cfg(feature = "ahash")]
-    {
-        //This enables specialization to improve performance on primitive types
-        use ahash::CallHasher;
-        let state = hash_builder.build_hasher();
-        K::get_hash(val, state)
-    }
-    #[cfg(not(feature = "ahash"))]
-    {
-        use core::hash::Hasher;
-        let mut state = hash_builder.build_hasher();
-        val.hash(&mut state);
-        state.finish()
-    }
+    use core::hash::Hasher;
+    let mut state = hash_builder.build_hasher();
+    val.hash(&mut state);
+    state.finish()
 }
 
 #[cfg(feature = "ahash")]


### PR DESCRIPTION
Unfortunately this feature causes compatibility issues with code that calculates hashes manually and then uses them with `RawEntryBuilderMut::from_hash` or `RawEntryBuilderMut::from_key_hashed_nocheck`.

We may want to re-introduce this in the future, but this would require a comprehensive plan to address the breakage.