### PR TITLE
Add `pub` modifier to `BumpWrapper`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub enum UnavailableMutError {
 /// the `allocator-api` feature of the `bumpalo` crate.
 #[cfg(feature = "bumpalo")]
 #[derive(Clone, Copy, Debug)]
-pub struct BumpWrapper<'a>(&'a bumpalo::Bump);
+pub struct BumpWrapper<'a>(pub &'a bumpalo::Bump);
 
 #[cfg(feature = "bumpalo")]
 #[test]


### PR DESCRIPTION
Without this change, I'm seeing the following error when trying to use the `BumpWrapper` feature in my own code.

```
error[E0423]: cannot initialize a tuple struct which contains private fields
   |
   |             HashSet::new_in(BumpWrapper(arena))
   |                             ^^^^^^^^^^^ constructor is not visible here due to private fields
```

`arena` is of type `&Bump`, matching the example given in the `test_bumpalo` test: `HashMap::new_in(BumpWrapper(&bump));`.