### PR TITLE
Add an allocator type parameter to HashMap's and HashSet's Clone impls

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -194,7 +194,7 @@ pub struct HashMap<K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> 
     pub(crate) table: RawTable<(K, V), A>,
 }
 
-impl<K: Clone, V: Clone, S: Clone> Clone for HashMap<K, V, S> {
+impl<K: Clone, V: Clone, S: Clone, A: Allocator + Clone> Clone for HashMap<K, V, S, A> {
     fn clone(&self) -> Self {
         HashMap {
             hash_builder: self.hash_builder.clone(),

--- a/src/set.rs
+++ b/src/set.rs
@@ -116,7 +116,7 @@ pub struct HashSet<T, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
     pub(crate) map: HashMap<T, (), S, A>,
 }
 
-impl<T: Clone, S: Clone> Clone for HashSet<T, S> {
+impl<T: Clone, S: Clone, A: Allocator + Clone> Clone for HashSet<T, S, A> {
     fn clone(&self) -> Self {
         HashSet {
             map: self.map.clone(),


### PR DESCRIPTION
HashMap's and HashSet's Clone implementations are missing the type parameter for a custom allocator, which makes them a lot less usable with custom allocators. Curiously, the parameter is present on RawTable's Clone implementation, so I figured that this must be an accident. This PR adds the parameter to HashMap and HashSet's Clone impls.

Here's a minimal reproducible example:
```rust
#![feature(allocator_api)]
use std::{
    alloc::{AllocError, Allocator, Global, Layout},
    ptr::NonNull,
};
use hashbrown::HashMap;

#[derive(Debug, Clone, Copy)]
pub struct DummyAllocator;

unsafe impl Allocator for DummyAllocator {
    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
        Global.allocate(layout)
    }

    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
        Global.deallocate(ptr, layout)
    }
}

fn main() {
    let map = HashMap::new_in(DummyAllocator);
    // Error: no method named `clone` found for struct `hashbrown::HashMap<&str, &str, ahash::random_state::RandomState, DummyAllocator>` in the current scope
    let map2 = map.clone();
}
```