### PR TITLE
Make `RawTable::insert_no_grow` unsafe

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -872,19 +872,17 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// This does not check if the given element already exists in the table.
     #[cfg_attr(feature = "inline-more", inline)]
     #[cfg(any(feature = "raw", feature = "rustc-internal-api"))]
-    pub fn insert_no_grow(&mut self, hash: u64, value: T) -> Bucket<T> {
-        unsafe {
-            let (index, old_ctrl) = self.table.prepare_insert_slot(hash);
-            let bucket = self.table.bucket(index);
+    pub unsafe fn insert_no_grow(&mut self, hash: u64, value: T) -> Bucket<T> {
+        let (index, old_ctrl) = self.table.prepare_insert_slot(hash);
+        let bucket = self.table.bucket(index);
 
-            // If we are replacing a DELETED entry then we don't need to update
-            // the load counter.
-            self.table.growth_left -= special_is_empty(old_ctrl) as usize;
+        // If we are replacing a DELETED entry then we don't need to update
+        // the load counter.
+        self.table.growth_left -= special_is_empty(old_ctrl) as usize;
 
-            bucket.write(value);
-            self.table.items += 1;
-            bucket
-        }
+        bucket.write(value);
+        self.table.items += 1;
+        bucket
     }
 
     /// Temporary removes a bucket, applying the given function to the removed

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -574,8 +574,10 @@ impl<'a, K, V, A: Allocator + Clone> RustcVacantEntry<'a, K, V, A> {
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(self, value: V) -> &'a mut V {
-        let bucket = self.table.insert_no_grow(self.hash, (self.key, value));
-        unsafe { &mut bucket.as_mut().1 }
+        unsafe {
+            let bucket = self.table.insert_no_grow(self.hash, (self.key, value));
+            &mut bucket.as_mut().1
+        }
     }
 
     /// Sets the value of the entry with the RustcVacantEntry's key,
@@ -596,7 +598,7 @@ impl<'a, K, V, A: Allocator + Clone> RustcVacantEntry<'a, K, V, A> {
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert_entry(self, value: V) -> RustcOccupiedEntry<'a, K, V, A> {
-        let bucket = self.table.insert_no_grow(self.hash, (self.key, value));
+        let bucket = unsafe { self.table.insert_no_grow(self.hash, (self.key, value)) };
         RustcOccupiedEntry {
             key: None,
             elem: bucket,


### PR DESCRIPTION
For performance reasons, this method _assumes_ that there is sufficient
capacity for the new element, and it misbehaves otherwise, breaking
invariants or even segfaulting. The necessary conditions could be
checked, but if we're to keep it lean, it should be `unsafe`, so the
burden is on the caller to ensure capacity.

Fixes #253.