### PR TITLE
Add an allocator() getter to HashMap and HashSet

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -395,6 +395,12 @@ impl<K, V, S> HashMap<K, V, S> {
 }
 
 impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
+    /// Returns a reference to the underlying allocator.
+    #[inline]
+    pub fn allocator(&self) -> &A {
+        self.table.allocator()
+    }
+
     /// Creates an empty `HashMap` which will use the given hash builder to hash
     /// keys. It will be allocated with the given allocator.
     ///

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -492,6 +492,12 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
         }
     }
 
+    /// Returns a reference to the underlying allocator.
+    #[inline]
+    pub fn allocator(&self) -> &A {
+        &self.table.alloc
+    }
+
     /// Deallocates the table without dropping any entries.
     #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn free_buckets(&mut self) {

--- a/src/set.rs
+++ b/src/set.rs
@@ -454,6 +454,12 @@ impl<T, S, A> HashSet<T, S, A>
 where
     A: Allocator + Clone,
 {
+    /// Returns a reference to the underlying allocator.
+    #[inline]
+    pub fn allocator(&self) -> &A {
+        self.map.allocator()
+    }
+
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
     ///


### PR DESCRIPTION
As far as I can tell, both HashMap and HashSet are currently missing an API to retrieve the underlying allocator, which makes using them less ergonomic due to the need to plumb it everywhere. [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.allocator) and [Box](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.allocator) have this method, and I couldn't think of anything that would make its presence unsuitable, so this PR adds the getter to the  collections.