### PR TITLE
Use u64 for the GroupWord on WebAssembly

### DIFF
--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -9,12 +9,14 @@ use core::{mem, ptr};
     target_pointer_width = "64",
     target_arch = "aarch64",
     target_arch = "x86_64",
+    target_arch = "wasm32",
 ))]
 type GroupWord = u64;
 #[cfg(all(
     target_pointer_width = "32",
     not(target_arch = "aarch64"),
     not(target_arch = "x86_64"),
+    not(target_arch = "wasm32"),
 ))]
 type GroupWord = u32;
 


### PR DESCRIPTION
Whether using 128-bit long SIMD vectors makes sense on WebAssembly is a bit unclear with the bitmask operations on those not being able to be lowered efficiently with NEON. However even the case without SIMD can be improved as wasm32 is an architecture which has 32-bit pointers, but native support for 64-bit integers. So the current general logic, that uses the pointer size in most cases, needs to be special cased for wasm32.