### PR TITLE
adjustment to make clippy happy

### DIFF
--- a/src/set.rs
+++ b/src/set.rs
@@ -1168,7 +1168,7 @@ where
 {
     #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
-        self.extend(iter.into_iter().cloned());
+        self.extend(iter.into_iter().copied());
     }
 
     #[inline]


### PR DESCRIPTION
It seems clippy does not like `cloned()` when `copied()` can be used.
See <https://github.com/rust-lang/hashbrown/runs/2967101005> for
the details.