### PR TITLE
Optimize `find`

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1054,7 +1054,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// `RawIterHash`. Because we cannot make the `next` method unsafe on the
     /// `RawIterHash` struct, we have to make the `iter_hash` method unsafe.
     #[cfg_attr(feature = "inline-more", inline)]
-    #[allow(dead_code)] // Used when the `raw` API is enabled
+    #[cfg(feature = "raw")]
     pub unsafe fn iter_hash(&self, hash: u64) -> RawIterHash<'_, T, A> {
         RawIterHash::new(self, hash)
     }
@@ -2214,6 +2214,7 @@ struct RawIterHashInner<'a, A: Allocator + Clone> {
 
 impl<'a, T, A: Allocator + Clone> RawIterHash<'a, T, A> {
     #[cfg_attr(feature = "inline-more", inline)]
+    #[cfg(feature = "raw")]
     fn new(table: &'a RawTable<T, A>, hash: u64) -> Self {
         RawIterHash {
             inner: RawIterHashInner::new(&table.table, hash),
@@ -2223,6 +2224,7 @@ impl<'a, T, A: Allocator + Clone> RawIterHash<'a, T, A> {
 }
 impl<'a, A: Allocator + Clone> RawIterHashInner<'a, A> {
     #[cfg_attr(feature = "inline-more", inline)]
+    #[cfg(feature = "raw")]
     fn new(table: &'a RawTableInner<A>, hash: u64) -> Self {
         unsafe {
             let h2_hash = h2(hash);


### PR DESCRIPTION
This optimizes `find` for size and performance.

The `cargo llvm-lines` output from the following program is reduced from 15837 to 15771.
```rust
fn main() {
    let mut map1 = hashbrown::HashMap::new();
    map1.insert(1u8, "");
    map1.reserve(1000);
    dbg!(map1.get(&1));
    let mut map2 = hashbrown::HashMap::new();
    map2.insert(1i16, "");
    map2.reserve(1000);
    dbg!(map2.get(&1));
    let mut map3 = hashbrown::HashMap::new();
    map3.insert(3u16, "");
    map3.reserve(1000);
    dbg!(map3.get(&1));
    let mut map4 = hashbrown::HashMap::new();
    map4.insert(3u64, "");
    map4.reserve(1000);
    dbg!(map4.get(&1));
    dbg!((
        map1.iter().next(),
        map2.iter().next(),
        map3.iter().next(),
        map4.iter().next()
    ));
}
```

`rustc_driver` size (with optimizations) is reduced by 0.14%.

Impact on compiler performance:
```
clap:check                        1.9602s   1.9407s  -0.99%
helloworld:check                  0.0420s   0.0420s  +0.06%
hyper:check                       0.2977s   0.2968s  -0.30%
regex:check                       1.1573s   1.1475s  -0.85%
syn:check                         1.6993s   1.6870s  -0.73%
syntex_syntax:check               6.8989s   6.8263s  -1.05%
winapi:check                      8.4423s   8.3300s  -1.33%

Total                            20.4977s  20.2702s  -1.11%
Summary                           3.5000s   3.4740s  -0.74%
```