### PR TITLE
Inline `static_empty`

### DIFF
--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -52,6 +52,7 @@ impl Group {
     /// value for an empty hash table.
     ///
     /// This is guaranteed to be aligned to the group size.
+    #[inline]
     pub const fn static_empty() -> &'static [u8; Group::WIDTH] {
         #[repr(C)]
         struct AlignedBytes {

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -28,6 +28,7 @@ impl Group {
     /// value for an empty hash table.
     ///
     /// This is guaranteed to be aligned to the group size.
+    #[inline]
     #[allow(clippy::items_after_statements)]
     pub const fn static_empty() -> &'static [u8; Group::WIDTH] {
         #[repr(C)]


### PR DESCRIPTION
This ended up not being inlined into `reserve_rehash`.