### PR TITLE
Make rehashing and resizing less generic

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1229,12 +1229,7 @@ impl<A: Allocator + Clone> RawTableInner<A> {
         debug_assert_ne!(self.bucket_mask, 0);
         debug_assert!(index < self.buckets());
         let base: *mut u8 = self.data_end().as_ptr();
-        if size_of == 0 {
-            // FIXME: Check if this `data_end` is aligned with ZST?
-            base
-        } else {
-            base.sub((index + 1) * size_of)
-        }
+        base.sub((index + 1) * size_of)
     }
 
     #[cfg_attr(feature = "inline-more", inline)]


### PR DESCRIPTION
This makes the code in `rehash_in_place`, `resize` and `reserve_rehash` less generic on `T`. It also improves the performance of rustc. That performance increase in partially attributed to the use of `#[inline(always)]`.

This is the effect on rustc runtime:
```
clap:check                        1.9523s   1.9327s  -1.00%
hashmap-instances:check           0.0628s   0.0624s  -0.57%
helloworld:check                  0.0438s   0.0436s  -0.50%
hyper:check                       0.2987s   0.2970s  -0.59%
regex:check                       1.1497s   1.1402s  -0.82%
syn:check                         1.7004s   1.6851s  -0.90%
syntex_syntax:check               6.9232s   6.8546s  -0.99%
winapi:check                      8.3220s   8.2857s  -0.44%

Total                            20.4528s  20.3014s  -0.74%
Summary                           4.0000s   3.9709s  -0.73%
```
`rustc_driver`'s code size is increased by 0.02%.

This is the effect on compile time this has on my [HashMap compile time benchmark](https://github.com/rust-lang/hashbrown/pull/277#issuecomment-881033607):
```
hashmap-instances:check           0.0636s   0.0632s  -0.61%
hashmap-instances:release        33.0166s  32.2487s  -2.33%
hashmap-instances:debug           7.8677s   7.2012s  -8.47%

Total                            40.9479s  39.5131s  -3.50%
Summary                           1.5000s   1.4430s  -3.80%
```
The `hashmap-instances:debug` compile time could be further improved if there was a way to apply `#[inline(always)]` only on release builds.