### PR TITLE
Use a weaker inline hint on `rehash_in_place`

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1456,7 +1456,8 @@ impl<A: Allocator + Clone> RawTableInner<A> {
     /// This uses dynamic dispatch to reduce the amount of
     /// code generated, but it is eliminated by LLVM optimizations when inlined.
     #[allow(clippy::inline_always)]
-    #[inline(always)]
+    #[cfg_attr(feature = "inline-more", inline(always))]
+    #[cfg_attr(not(feature = "inline-more"), inline)]
     unsafe fn rehash_in_place(
         &mut self,
         hasher: &dyn Fn(&mut Self, usize) -> u64,


### PR DESCRIPTION
My hypothesis is that rehashing is sufficiently rare to not pay the compile time cost for `inline(always)` here.

It doesn't seem to affect rustc performance (there's a hash map in the query system which may be prone to rehashing):
```
clap:check                        1.9752s   1.9734s  -0.09%
hashmap-instances:check           0.0633s   0.0632s  -0.15%
helloworld:check                  0.0439s   0.0439s  -0.13%
hyper:check                       0.2973s   0.2971s  -0.07%
regex:check                       1.1629s   1.1619s  -0.09%
syn:check                         1.7175s   1.7189s  +0.08%
syntex_syntax:check               6.9092s   6.9201s  +0.16%
winapi:check                      8.3311s   8.3358s  +0.06%

Total                            20.5005s  20.5142s  +0.07%
Summary                           4.0000s   3.9988s  -0.03%
```


It seems to mostly help `debug` build times for `hashmap-instances`. I suspect LLVM ends up inlining all calls in release mode anyway here.
```
hashmap-instances:check           0.0640s   0.0642s  +0.28%
hashmap-instances:release        32.5073s  32.3996s  -0.33%
hashmap-instances:debug           7.2279s   6.7838s  -6.14%

Total                            39.7993s  39.2477s  -1.39%
Summary                           1.5000s   1.4690s  -2.07%
```