### PR TITLE
Apply s̶o̶m̶e  all clippy suggestions found in tests

### DIFF
--- a/ci/tools.sh
+++ b/ci/tools.sh
@@ -30,7 +30,7 @@ if retry rustup component add rustfmt ; then
 fi
 
 if retry rustup component add clippy ; then
-    cargo clippy --all -- -D clippy::all -D clippy::pedantic
+    cargo clippy --all --tests -- -D clippy::all -D clippy::pedantic
 fi
 
 if command -v shellcheck ; then

--- a/src/map.rs
+++ b/src/map.rs
@@ -3556,6 +3556,7 @@ mod test_map {
         assert_eq!(m.len(), 1);
         assert!(m.insert(2, 4).is_none());
         assert_eq!(m.len(), 2);
+        #[allow(clippy::redundant_clone)]
         let m2 = m.clone();
         assert_eq!(*m2.get(&1).unwrap(), 2);
         assert_eq!(*m2.get(&2).unwrap(), 4);
@@ -4191,6 +4192,7 @@ mod test_map {
         map.insert(2, 1);
         map.insert(3, 4);
 
+        #[allow(clippy::no_effect)] // false positive lint
         map[&4];
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -3943,7 +3943,7 @@ mod test_map {
         let vec = vec![(1, 1), (2, 2), (3, 3)];
         let mut map: HashMap<_, _> = vec.into_iter().collect();
         for value in map.values_mut() {
-            *value = (*value) * 2
+            *value *= 2
         }
         let values: Vec<_> = map.values().cloned().collect();
         assert_eq!(values.len(), 3);
@@ -4327,11 +4327,11 @@ mod test_map {
         let key = "hello there";
         let value = "value goes here";
         assert!(a.is_empty());
-        a.insert(key.clone(), value.clone());
+        a.insert(key, value);
         assert_eq!(a.len(), 1);
         assert_eq!(a[key], value);
 
-        match a.entry(key.clone()) {
+        match a.entry(key) {
             Vacant(_) => panic!(),
             Occupied(e) => assert_eq!(key, *e.key()),
         }
@@ -4346,11 +4346,11 @@ mod test_map {
         let value = "value goes here";
 
         assert!(a.is_empty());
-        match a.entry(key.clone()) {
+        match a.entry(key) {
             Occupied(_) => panic!(),
             Vacant(e) => {
                 assert_eq!(key, *e.key());
-                e.insert(value.clone());
+                e.insert(value);
             }
         }
         assert_eq!(a.len(), 1);
@@ -4876,7 +4876,7 @@ mod test_map {
         const EMPTY_MAP: HashMap<u32, std::string::String, MyHasher> =
             HashMap::with_hasher(MyHasher);
 
-        let mut map = EMPTY_MAP.clone();
+        let mut map = EMPTY_MAP;
         map.insert(17, "seventeen".to_owned());
         assert_eq!("seventeen", map[&17]);
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -2278,7 +2278,7 @@ mod test_set {
 
         const EMPTY_SET: HashSet<u32, MyHasher> = HashSet::with_hasher(MyHasher);
 
-        let mut set = EMPTY_SET.clone();
+        let mut set = EMPTY_SET;
         set.insert(19);
         assert!(set.contains(&19));
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1969,7 +1969,7 @@ mod test_set {
         let expected = [3, 5, 11, 77];
         for x in a.intersection(&b) {
             assert!(expected.contains(x));
-            i += 1
+            i += 1;
         }
         assert_eq!(i, expected.len());
     }
@@ -1992,7 +1992,7 @@ mod test_set {
         let expected = [1, 5, 11];
         for x in a.difference(&b) {
             assert!(expected.contains(x));
-            i += 1
+            i += 1;
         }
         assert_eq!(i, expected.len());
     }
@@ -2018,7 +2018,7 @@ mod test_set {
         let expected = [-2, 1, 5, 11, 14, 22];
         for x in a.symmetric_difference(&b) {
             assert!(expected.contains(x));
-            i += 1
+            i += 1;
         }
         assert_eq!(i, expected.len());
     }
@@ -2048,7 +2048,7 @@ mod test_set {
         let expected = [-2, 1, 3, 5, 9, 11, 13, 16, 19, 24];
         for x in a.union(&b) {
             assert!(expected.contains(x));
-            i += 1
+            i += 1;
         }
         assert_eq!(i, expected.len());
     }
@@ -2074,7 +2074,7 @@ mod test_set {
     fn test_from_iter() {
         let xs = [1, 2, 2, 3, 4, 5, 6, 7, 8, 9];
 
-        let set: HashSet<_> = xs.iter().cloned().collect();
+        let set: HashSet<_> = xs.iter().copied().collect();
 
         for x in &xs {
             assert!(set.contains(x));
@@ -2236,7 +2236,7 @@ mod test_set {
     #[test]
     fn test_retain() {
         let xs = [1, 2, 3, 4, 5, 6];
-        let mut set: HashSet<i32> = xs.iter().cloned().collect();
+        let mut set: HashSet<i32> = xs.iter().copied().collect();
         set.retain(|&k| k % 2 == 0);
         assert_eq!(set.len(), 3);
         assert!(set.contains(&2));

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -21,7 +21,7 @@ fn test_hashset_insert_remove() {
     // more readable with explicit `true` / `false`
     #[allow(clippy::bool_assert_comparison)]
     for _ in 0..32 {
-        for x in tx.iter() {
+        for x in &tx {
             assert_eq!(m.contains(x), false);
             assert_eq!(m.insert(x.clone()), true);
         }

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -2,20 +2,21 @@
 
 use hashbrown::HashSet;
 use rand::{distributions::Alphanumeric, rngs::SmallRng, Rng, SeedableRng};
+use std::iter;
 
 #[test]
 fn test_hashset_insert_remove() {
     let mut m: HashSet<Vec<char>> = HashSet::new();
-    //let num: u32 = 4096;
-    //let tx: Vec<Vec<u8>> = (0..num).map(|i| (i..(16 + i)).collect()).collect();
+
     let seed: [u8; 16] = [
         130, 220, 246, 217, 111, 124, 221, 189, 190, 234, 121, 93, 67, 95, 100, 43,
     ];
 
     let rng = &mut SmallRng::from_seed(seed);
-    let tx: Vec<Vec<char>> = (0..4096)
-        .map(|_| (rng.sample_iter(&Alphanumeric).take(32).collect()))
-        .collect();
+    let tx: Vec<Vec<char>> =
+        iter::repeat_with(|| rng.sample_iter(&Alphanumeric).take(32).collect())
+            .take(4096)
+            .collect();
 
     // more readable with explicit `true` / `false`
     #[allow(clippy::bool_assert_comparison)]

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -17,14 +17,16 @@ fn test_hashset_insert_remove() {
         .map(|_| (rng.sample_iter(&Alphanumeric).take(32).collect()))
         .collect();
 
+    // more readable with explicit `true` / `false`
+    #[allow(clippy::bool_assert_comparison)]
     for _ in 0..32 {
-        for i in 0..4096 {
-            assert_eq!(m.contains(&tx[i].clone()), false);
-            assert_eq!(m.insert(tx[i].clone()), true);
+        for x in tx.iter() {
+            assert_eq!(m.contains(x), false);
+            assert_eq!(m.insert(x.clone()), true);
         }
-        for i in 0..4096 {
-            println!("removing {} {:?}", i, tx[i]);
-            assert_eq!(m.remove(&tx[i]), true);
+        for (i, x) in tx.iter().enumerate() {
+            println!("removing {} {:?}", i, x);
+            assert_eq!(m.remove(x), true);
         }
     }
 }


### PR DESCRIPTION
Apply some clippy suggestions to tests, involving
* removing calls to `.clone()` on `&str`s,
* removing calls to `.clone()` on `const`s,
* a transformation `x = x * 2` →  `x *= 2`.

All of these seem like definite improvements to me.

In particular the `clone()`s on `&str` are a deny-by-default clippy lint ([`clippy::clone_double_ref`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_double_ref)) and I don’t like the red marks in my IDE.