### PR TITLE
Fix instances of clippy::semicolon_if_nothing_returned

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1672,7 +1672,7 @@ pub(super) struct ConsumeAllOnDrop<'a, T: Iterator>(pub &'a mut T);
 impl<T: Iterator> Drop for ConsumeAllOnDrop<'_, T> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn drop(&mut self) {
-        self.0.for_each(drop)
+        self.0.for_each(drop);
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1709,7 +1709,7 @@ impl<K, V, A: Allocator + Clone> DrainFilterInner<'_, K, V, A> {
         F: FnMut(&K, &mut V) -> bool,
     {
         unsafe {
-            while let Some(item) = self.iter.next() {
+            for item in &mut self.iter {
                 let &mut (ref key, ref mut value) = item.as_mut();
                 if f(key, value) {
                     return Some(self.table.remove(item));

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -47,7 +47,7 @@ mod inner {
         }
         #[inline]
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-            dealloc(ptr.as_ptr(), layout)
+            dealloc(ptr.as_ptr(), layout);
         }
     }
     impl Default for Global {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -59,7 +59,7 @@ fn cold() {}
 #[inline]
 fn likely(b: bool) -> bool {
     if !b {
-        cold()
+        cold();
     }
     b
 }
@@ -67,7 +67,7 @@ fn likely(b: bool) -> bool {
 #[inline]
 fn unlikely(b: bool) -> bool {
     if b {
-        cold()
+        cold();
     }
     b
 }
@@ -502,7 +502,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// Deallocates the table without dropping any entries.
     #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn free_buckets(&mut self) {
-        self.table.free_buckets(TableLayout::new::<T>())
+        self.table.free_buckets(TableLayout::new::<T>());
     }
 
     /// Returns pointer to one past last element of data table.
@@ -537,7 +537,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     #[deprecated(since = "0.8.1", note = "use erase or remove instead")]
     pub unsafe fn erase_no_drop(&mut self, item: &Bucket<T>) {
         let index = self.bucket_index(item);
-        self.table.erase(index)
+        self.table.erase(index);
     }
 
     /// Erases an element from the table, dropping it in place.
@@ -586,7 +586,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// Marks all table buckets as empty without dropping their contents.
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn clear_no_drop(&mut self) {
-        self.table.clear_no_drop()
+        self.table.clear_no_drop();
     }
 
     /// Removes all elements from the table without freeing the backing memory.
@@ -631,7 +631,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
         if min_buckets < self.buckets() {
             // Fast path if the table is empty
             if self.table.items == 0 {
-                *self = Self::with_capacity_in(min_size, self.table.alloc.clone())
+                *self = Self::with_capacity_in(min_size, self.table.alloc.clone());
             } else {
                 // Avoid `Result::unwrap_or_else` because it bloats LLVM IR.
                 if self
@@ -1271,7 +1271,7 @@ impl<A: Allocator + Clone> RawTableInner<A> {
     /// the end of the array.
     #[inline]
     unsafe fn set_ctrl_h2(&self, index: usize, hash: u64) {
-        self.set_ctrl(index, h2(hash))
+        self.set_ctrl(index, h2(hash));
     }
 
     #[inline]
@@ -1646,7 +1646,7 @@ impl<T: Clone, A: Allocator + Clone> Clone for RawTable<T, A> {
 
                 self.clone_from_spec(source, |self_| {
                     // We need to leave the table in an empty state.
-                    self_.clear_no_drop()
+                    self_.clear_no_drop();
                 });
             }
         }

--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -44,6 +44,6 @@ where
 {
     #[inline]
     fn drop(&mut self) {
-        (self.dropfn)(&mut self.value)
+        (self.dropfn)(&mut self.value);
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -378,7 +378,7 @@ impl<T, S, A: Allocator + Clone> HashSet<T, S, A> {
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn clear(&mut self) {
-        self.map.clear()
+        self.map.clear();
     }
 }
 
@@ -559,7 +559,7 @@ where
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn reserve(&mut self, additional: usize) {
-        self.map.reserve(additional)
+        self.map.reserve(additional);
     }
 
     /// Tries to reserve capacity for at least `additional` more elements to be inserted
@@ -601,7 +601,7 @@ where
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn shrink_to_fit(&mut self) {
-        self.map.shrink_to_fit()
+        self.map.shrink_to_fit();
     }
 
     /// Shrinks the capacity of the set with a lower limit. It will drop
@@ -627,7 +627,7 @@ where
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn shrink_to(&mut self, min_capacity: usize) {
-        self.map.shrink_to(min_capacity)
+        self.map.shrink_to(min_capacity);
     }
 
     /// Visits the values representing the difference,


### PR DESCRIPTION
Fix instances of clippy::semicolon_if_nothing_returned in order to make CI pass again.