### PR TITLE
Rename get_each_mut to get_many_mut and align API with the stdlib

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,20 +129,6 @@ pub enum TryReserveError {
     },
 }
 
-/// The error type for [`RawTable::get_each_mut`](crate::raw::RawTable::get_each_mut),
-/// [`HashMap::get_each_mut`], and [`HashMap::get_each_key_value_mut`].
-#[cfg(feature = "nightly")]
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum UnavailableMutError {
-    /// The requested entry is not present in the table.
-    Absent,
-    /// The requested entry is present, but a mutable reference to it was already created and
-    /// returned from this call to `get_each_mut` or `get_each_key_value_mut`.
-    ///
-    /// Includes the index of the existing mutable reference in the returned array.
-    Duplicate(usize),
-}
-
 /// Wrapper around `Bump` which allows it to be used as an allocator for
 /// `HashMap`, `HashSet` and `RawTable`.
 ///


### PR DESCRIPTION
The standard library will be gaining a similar [ability for slices][]. This updates Hashbrown's API to match that PR and use only stable `MaybeUninit` functions.

This change requires a MSRV bump to Rust 1.51.

[ability for slices]: https://github.com/rust-lang/rust/pull/83608