### PR TITLE
Use `BuildHasher::hash_one` when `feature = "nightly"` is enabled.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@
         allocator_api,
         slice_ptr_get,
         nonnull_slice_from_raw_parts,
-        maybe_uninit_array_assume_init
+        maybe_uninit_array_assume_init,
+        build_hasher_simple_hash_one
     )
 )]
 #![allow(


### PR DESCRIPTION
I describe why this is good for more than just convenience here: https://github.com/rust-lang/rust/issues/86161#issuecomment-916577133