### PR TITLE
Relax the bounds on HashSet: Debug

### DIFF
--- a/src/set.rs
+++ b/src/set.rs
@@ -1128,8 +1128,7 @@ where
 
 impl<T, S, A> fmt::Debug for HashSet<T, S, A>
 where
-    T: Eq + Hash + fmt::Debug,
-    S: BuildHasher,
+    T: fmt::Debug,
     A: Allocator + Clone,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This looks to be just an oversight.

The bounds on `HashMap` are similarly loose:

https://github.com/rust-lang/hashbrown/blob/1e1bb230bc376f6db99e08c055fd758d142aa72d/src/map.rs#L1540-L1545

And `std::collections::HashSet` has always only bounded `T` by `Debug` and not `Eq`/`Hash` here.