### PR TITLE
Issue #297: Implement From<array> on HashSet and HashMap

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,10 +60,10 @@ jobs:
           channel: nightly
         - os: macos-latest
           target: x86_64-apple-darwin
-          channel: 1.49.0
+          channel: 1.56.1
         - os: windows-latest
           target: x86_64-pc-windows-msvc
-          channel: 1.49.0
+          channel: 1.56.1
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           channel: beta

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           thumbv6m-none-eabi,
           x86_64-pc-windows-gnu,
         ]
-        channel: [1.49.0, nightly]
+        channel: [1.56.1, nightly]
         include:
         - os: macos-latest
           target: x86_64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Bumped minimum Rust version to 1.65.1 and edition to 2021
+- Added `From<[T; N]>` and `From<[(K, V); N]>` for `HashSet` and `HashMap` respectively (#297)
+
 ## [v0.11.2] - 2021-03-25
 
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["hash", "no_std", "hashmap", "swisstable"]
 categories = ["data-structures", "no-std"]
 exclude = [".github", "bors.toml", "/ci/*"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # For the default hasher

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hashbrown
 [![Build Status](https://github.com/rust-lang/hashbrown/actions/workflows/rust.yml/badge.svg)](https://github.com/rust-lang/hashbrown/actions)
 [![Crates.io](https://img.shields.io/crates/v/hashbrown.svg)](https://crates.io/crates/hashbrown)
 [![Documentation](https://docs.rs/hashbrown/badge.svg)](https://docs.rs/hashbrown)
-[![Rust](https://img.shields.io/badge/rust-1.49.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
+[![Rust](https://img.shields.io/badge/rust-1.65.1%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
 
 This crate is a Rust port of Google's high-performance [SwissTable] hash
 map, adapted to make it a drop-in replacement for Rust's standard `HashMap`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hashbrown
 [![Build Status](https://github.com/rust-lang/hashbrown/actions/workflows/rust.yml/badge.svg)](https://github.com/rust-lang/hashbrown/actions)
 [![Crates.io](https://img.shields.io/crates/v/hashbrown.svg)](https://crates.io/crates/hashbrown)
 [![Documentation](https://docs.rs/hashbrown/badge.svg)](https://docs.rs/hashbrown)
-[![Rust](https://img.shields.io/badge/rust-1.65.1%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
+[![Rust](https://img.shields.io/badge/rust-1.56.1%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
 
 This crate is a Rust port of Google's high-performance [SwissTable] hash
 map, adapted to make it a drop-in replacement for Rust's standard `HashMap`

--- a/src/map.rs
+++ b/src/map.rs
@@ -1581,6 +1581,7 @@ where
 }
 
 // The default hasher is used to match the std implementation signature
+#[cfg(feature = "ahash")]
 impl<K, V, A, const N: usize> From<[(K, V); N]> for HashMap<K, V, DefaultHashBuilder, A>
 where
     K: Eq + Hash,

--- a/src/map.rs
+++ b/src/map.rs
@@ -1580,6 +1580,26 @@ where
     }
 }
 
+// The default hasher is used to match the std implementation signature
+impl<K, V, A, const N: usize> From<[(K, V); N]> for HashMap<K, V, DefaultHashBuilder, A>
+where
+    K: Eq + Hash,
+    A: Default + Allocator + Clone,
+{
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    ///
+    /// let map1 = HashMap::from([(1, 2), (3, 4)]);
+    /// let map2: HashMap<_, _> = [(1, 2), (3, 4)].into();
+    /// assert_eq!(map1, map2);
+    /// ```
+    fn from(arr: [(K, V); N]) -> Self {
+        arr.into_iter().collect()
+    }
+}
+
 /// An iterator over the entries of a `HashMap`.
 ///
 /// This `struct` is created by the [`iter`] method on [`HashMap`]. See its

--- a/src/set.rs
+++ b/src/set.rs
@@ -1159,6 +1159,27 @@ where
     }
 }
 
+// The default hasher is used to match the std implementation signature
+// see https://doc.rust-lang.org/src/std/collections/hash/set.rs.html#1010-1026
+impl<T, A, const N: usize> From<[T; N]> for HashSet<T, DefaultHashBuilder, A>
+where
+    T: Eq + Hash,
+    A: Default + Allocator + Clone,
+{
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashSet;
+    ///
+    /// let set1 = HashSet::from([1, 2, 3, 4]);
+    /// let set2: HashSet<_> = [1, 2, 3, 4].into();
+    /// assert_eq!(set1, set2);
+    /// ```
+    fn from(arr: [T; N]) -> Self {
+        arr.into_iter().collect()
+    }
+}
+
 impl<T, S, A> Extend<T> for HashSet<T, S, A>
 where
     T: Eq + Hash,

--- a/src/set.rs
+++ b/src/set.rs
@@ -1160,6 +1160,7 @@ where
 }
 
 // The default hasher is used to match the std implementation signature
+#[cfg(feature = "ahash")]
 impl<T, A, const N: usize> From<[T; N]> for HashSet<T, DefaultHashBuilder, A>
 where
     T: Eq + Hash,

--- a/src/set.rs
+++ b/src/set.rs
@@ -1160,7 +1160,6 @@ where
 }
 
 // The default hasher is used to match the std implementation signature
-// see https://doc.rust-lang.org/src/std/collections/hash/set.rs.html#1010-1026
 impl<T, A, const N: usize> From<[T; N]> for HashSet<T, DefaultHashBuilder, A>
 where
     T: Eq + Hash,


### PR DESCRIPTION
Implemented From<[T; N]> on HashSet and From<[(K, V); N]> on HashMap.  In both cases, the default hasher was used to match the implementations from the std crate (see https://doc.rust-lang.org/src/std/collections/hash/map.rs.html#1161-1190)

Edition was updated to 2021 to take advantage of the change in array's `.into_iter` method from iterating over `&T` to iterating over `T`.

Hopefully the implementations are trivial enough that tests aren't necessary ;)