### PR TITLE
update Miri CI config

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -5,11 +5,8 @@ set -ex
 export CARGO_NET_RETRY=5
 export CARGO_NET_TIMEOUT=10
 
-MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
-echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
-rustup default "$MIRI_NIGHTLY"
-
-rustup component add miri
+rustup toolchain install nightly --component miri
+rustup override set nightly
 cargo miri setup
 
 cargo miri test


### PR DESCRIPTION
We don't need `curl` and https://rust-lang.github.io/rustup-components-history/ any more now that `rustup` can install "latest toolchain with certain tools".