### PR TITLE
Removing additional third copy operation for OccupiedEntry::insert

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -3587,10 +3587,8 @@ impl<'a, K, V, S, A: Allocator + Clone> OccupiedEntry<'a, K, V, S, A> {
     /// assert_eq!(map["poneyland"], 15);
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn insert(&mut self, mut value: V) -> V {
-        let old_value = self.get_mut();
-        mem::swap(&mut value, old_value);
-        value
+    pub fn insert(&mut self, value: V) -> V {
+        mem::replace(self.get_mut(), value)
     }
 
     /// Takes the value out of the entry, and returns it.
@@ -4256,10 +4254,8 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> OccupiedEntryRef<'a, 'b, 
     /// assert_eq!(map["poneyland"], 15);
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn insert(&mut self, mut value: V) -> V {
-        let old_value = self.get_mut();
-        mem::swap(&mut value, old_value);
-        value
+    pub fn insert(&mut self, value: V) -> V {
+        mem::replace(self.get_mut(), value)
     }
 
     /// Takes the value out of the entry, and returns it.


### PR DESCRIPTION
Removing unnecessary additional third copy operation for `OccupiedEntry::insert` and `OccupiedEntryRef::insert` because with `swap`  we have three operation:
1. `Read` from `x` to the third value `z`,
2. `Copy` from `y` to `x`,
3. `Copy` from `z` to the `y` value.

But when we use `replace` funtion we actually do only first two operation and immediatly return z value and skip third `copy` operation