### PR TITLE
Removing third copy operation for RustcOccupiedEntry::insert

### DIFF
--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -431,10 +431,8 @@ impl<'a, K, V, A: Allocator + Clone> RustcOccupiedEntry<'a, K, V, A> {
     /// assert_eq!(map["poneyland"], 15);
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn insert(&mut self, mut value: V) -> V {
-        let old_value = self.get_mut();
-        mem::swap(&mut value, old_value);
-        value
+    pub fn insert(&mut self, value: V) -> V {
+        mem::remove(self.get_mut(), value)
     }
 
     /// Takes the value out of the entry, and returns it.

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -432,7 +432,7 @@ impl<'a, K, V, A: Allocator + Clone> RustcOccupiedEntry<'a, K, V, A> {
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(&mut self, value: V) -> V {
-        mem::remove(self.get_mut(), value)
+        mem::replace(self.get_mut(), value)
     }
 
     /// Takes the value out of the entry, and returns it.


### PR DESCRIPTION
Continuation of #327.