### PR TITLE
Deleting #[cfg(not(feature = "nightly"))] attributes

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -69,15 +69,9 @@ fn unlikely(b: bool) -> bool {
     b
 }
 
-#[cfg(feature = "nightly")]
 #[inline]
 unsafe fn offset_from<T>(to: *const T, from: *const T) -> usize {
     to.offset_from(from) as usize
-}
-#[cfg(not(feature = "nightly"))]
-#[inline]
-unsafe fn offset_from<T>(to: *const T, from: *const T) -> usize {
-    (to as usize - from as usize) / mem::size_of::<T>()
 }
 
 /// Whether memory allocation errors should return an error or abort.


### PR DESCRIPTION
Deleting two version of offset_from<T> function (for #[cfg(feature = "nightly")] and #[cfg(not(feature = "nightly"))]) because ptr::offset_from stable since rust 1.47.0.