### PR TITLE
Adding function for getting access to map `table: RawTable<(K, V), A>` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ rustc-dep-of-std = [
     "rustc-internal-api",
 ]
 raw = []
-map-inner = ["raw"]
 
 # Enables usage of `#[inline]` on far more functions than by default in this
 # crate. This may lead to a performance increase but often comes at a compile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rustc-dep-of-std = [
     "rustc-internal-api",
 ]
 raw = []
+map-inner = ["raw"]
 
 # Enables usage of `#[inline]` on far more functions than by default in this
 # crate. This may lead to a performance increase but often comes at a compile

--- a/src/map.rs
+++ b/src/map.rs
@@ -2047,10 +2047,10 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     ///     is_match: F,
     /// ) -> Option<(K, V)>
     /// where
-    ///     F: Fn(&K, &V) -> bool,
+    ///     F: Fn(&(K, V)) -> bool,
     /// {
     ///     let raw_table = map.raw_table();
-    ///     match raw_table.find(hash, |(k, v)| is_match(k, v)) {
+    ///     match raw_table.find(hash, is_match) {
     ///         Some(bucket) => Some(unsafe { raw_table.remove(bucket) }),
     ///         None => None,
     ///     }
@@ -2064,7 +2064,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// }
     ///
     /// let hash = compute_hash(map.hasher(), "a");
-    /// assert_eq!(remove_by_hash(&mut map, hash, |_, v| *v == 10), Some(("a", 10)));
+    /// assert_eq!(remove_by_hash(&mut map, hash, |(_, v)| *v == 10), Some(("a", 10)));
     /// assert_eq!(map.get(&"a"), None);
     /// assert_eq!(map.len(), 2);
     /// ```

--- a/src/map.rs
+++ b/src/map.rs
@@ -186,8 +186,15 @@ pub enum DefaultHashBuilder {}
 /// // use the values stored in map
 /// ```
 pub struct HashMap<K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
+    #[cfg(any(feature = "rustc-internal-api", not(feature = "map-inner")))]
     pub(crate) hash_builder: S,
+    #[cfg(any(feature = "rustc-internal-api", not(feature = "map-inner")))]
     pub(crate) table: RawTable<(K, V), A>,
+
+    #[cfg(all(feature = "map-inner", not(feature = "rustc-internal-api")))]
+    pub hash_builder: S,
+    #[cfg(all(feature = "map-inner", not(feature = "rustc-internal-api")))]
+    pub table: RawTable<(K, V), A>,
 }
 
 impl<K: Clone, V: Clone, S: Clone, A: Allocator + Clone> Clone for HashMap<K, V, S, A> {


### PR DESCRIPTION
I was a little interested in issues "API for removing by key hash and value" #330. The original question was about adding a fancy API, and of course it wasn't merged (#334).

However, it seems to me that this shows that it would be nice to just add the ability to access to map's fields. And let the user himself do what he pleases.

The user will still not be able to change the existing API. But at the same time, he will have the opportunity to add small extensions. Otherwise, when using `RawTable`, he will have to not only add one or two functions, but generally recreate all the `HashMap`’s APIs, which can be difficult.