### PR TITLE
 Allow unused macro rules for macro `cfg_if`.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 // See the cfg-if crate.
-#[allow(unused)]
+#[allow(unused_macro_rules)]
 macro_rules! cfg_if {
     // match if/else chains with a final `else`
     ($(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,5 @@
 // See the cfg-if crate.
+#[allow(unused)]
 macro_rules! cfg_if {
     // match if/else chains with a final `else`
     ($(


### PR DESCRIPTION
The unused macro rules lint is an new lint for the rust compiler: [rust-lang/rust#96150](https://github.com/rust-lang/rust/pull/96150)