### PR TITLE
Adding `Extend<&'a (K, V)> for HashMap<K, V, S, A>`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -7060,7 +7060,7 @@ mod test_map {
         a.extend(&create_arr::<i32, 100>(200, 1));
 
         assert_eq!(a.len(), 300);
-        
+
         for item in 0..300 {
             assert_eq!(a[&item], item);
         }


### PR DESCRIPTION
I think that it is strange that we can do something like this:
```rust
fn main() {
    use hashbrown::HashMap;
    let mut map = HashMap::new();
    let some_vec: Vec<_> = vec![(1, 1), (2, 2), (3, 3), (4, 4)];
    map.extend(some_vec.iter().map(|&(k, v)| (k, v)));
}
```
but cannot do something like this:
```rust
fn main() {
    use hashbrown::HashMap;
    let mut map = HashMap::new();
    let some_vec: Vec<_> = vec![(1, 1), (2, 2), (3, 3), (4, 4)];
    map.extend(some_vec.iter()); // Or map.extend(&some_vec);
}
```
In any case, it can work only if K and V are Copy, and also inside `Extend<(K, V)>` we use `HashMap::insert`, not `HashMap::insert_unique_unchecked`, so adding `Extend<&'a (K, V)>` should be Ok.