### PR TITLE
Editing `do_alloc` for reducing LLVM IR

### DIFF
--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -8,10 +8,10 @@ mod inner {
 
     #[allow(clippy::map_err_ignore)]
     pub fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
-        alloc
-            .allocate(layout)
-            .map(|ptr| ptr.as_non_null_ptr())
-            .map_err(|_| ())
+        match alloc.allocate(layout) {
+            Ok(ptr) => Ok(ptr.as_non_null_ptr()),
+            Err(_) => Err(()),
+        }
     }
 
     #[cfg(feature = "bumpalo")]


### PR DESCRIPTION
1. I think this will speed up compilation, since one way or another everything will come down to this code (but I didn’t compare performance).

2. I don’t know if the compiler was able to optimize that old code, but it literally checked the same thing twice (due to `map` and `map_err` in a row, and roughly speaking it came down to:
    ```rust
    pub fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
        match match alloc.allocate(layout) {
            Ok(ptr) => Ok(ptr.as_non_null_ptr()),
            Err(e) => Err(e),
        } {
            Ok(ptr) => Ok(ptr),
            Err(_) => Err(()),
        }
    }
    ```
    And when the code is written explicitly, it is immediately clear that it looks strange. And why force the compiler to think beyond the need?

3. And finally, in my opinion, the readability of the code has not only not decreased, but even increased.