### PR TITLE
Add an Entry API for HashSet

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -5573,7 +5573,7 @@ impl<'a, K, V, S, A: Allocator + Clone> VacantEntry<'a, K, V, S, A> {
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, S, A>
+    pub(crate) fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V, S, A>
     where
         K: Hash,
         S: BuildHasher,

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -56,10 +56,10 @@ where
 
 /// A view into a single entry in a map, which may either be vacant or occupied.
 ///
-/// This `enum` is constructed from the [`entry`] method on [`HashMap`].
+/// This `enum` is constructed from the [`rustc_entry`] method on [`HashMap`].
 ///
 /// [`HashMap`]: struct.HashMap.html
-/// [`entry`]: struct.HashMap.html#method.rustc_entry
+/// [`rustc_entry`]: struct.HashMap.html#method.rustc_entry
 pub enum RustcEntry<'a, K, V, A = Global>
 where
     A: Allocator + Clone,
@@ -145,7 +145,7 @@ impl<'a, K, V, A: Allocator + Clone> RustcEntry<'a, K, V, A> {
     /// use hashbrown::HashMap;
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
-    /// let entry = map.entry("horseyland").insert(37);
+    /// let entry = map.rustc_entry("horseyland").insert(37);
     ///
     /// assert_eq!(entry.key(), &"horseyland");
     /// ```


### PR DESCRIPTION
This adds `HashSet::entry` and `rustc_entry`, mimicking the API of `HashMap`. The "rustc" variants are without the `S` type parameter, just like the difference on maps. Set entries have fewer methods since there's no mutable value like in maps, but the basic insert/remove/replace functionality is there.

Resolves #274.