### PR TITLE
Allow compiling on 1.56.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["hash", "no_std", "hashmap", "swisstable"]
 categories = ["data-structures", "no-std"]
 exclude = [".github", "/ci/*"]
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.56.0"
 
 [dependencies]
 # For the default hasher


### PR DESCRIPTION
Rust 1.56.1 is only adding a compile warning for certain hidden unicode codepoints in source code, which sounds totally unrelated to hashbrown. See https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html and https://github.com/rust-lang/rust/compare/1.56.0...1.56.1. I don't see the point of forbidding users from compiling hashbrown using 1.56.0.