### PR TITLE
Bump version tested on CI to 1.58.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           thumbv6m-none-eabi,
           x86_64-pc-windows-gnu,
         ]
-        channel: [1.56.1, nightly]
+        channel: [1.58.1, nightly]
         include:
         - os: macos-latest
           target: x86_64-apple-darwin
@@ -60,9 +60,12 @@ jobs:
           channel: nightly
         - os: macos-latest
           target: x86_64-apple-darwin
-          channel: 1.56.1
+          channel: 1.58.1
         - os: windows-latest
           target: x86_64-pc-windows-msvc
+          channel: 1.58.1
+        - os: ubuntu-latest
+          target: x86_64-unknown-linux-gnu
           channel: 1.56.1
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
This is needed because cross-rs increased its MSRV to 1.58.1.

One CI builder is kept at 1.56.1 without using cross-rs to guarantee
that compatibility is maintained.