### PR TITLE
`Equivalent` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,39 @@ pub mod hash_set {
 pub use crate::map::HashMap;
 pub use crate::set::HashSet;
 
+/// Key equivalence trait.
+///
+/// This trait defines the function used to compare the input value with the
+/// map keys (or set values) during a lookup operation sur as [`HashMap::get`]
+/// or [`HashSet::contains`].
+/// It is provided with a blanket implementation based on the
+/// [`Borrow`](core::borrow::Borrow) trait.
+///
+/// # Correctness
+///
+/// Equivalent values must hash to the same value.
+pub trait Equivalent<K: ?Sized> {
+    /// Checks if this value is equivalent to the given key.
+    ///
+    /// Returns `true` if oth values are equivalent, and `false` otherwise.
+    ///
+    /// # Correctness
+    ///
+    /// When this function returns `true`, both `self` and `key` must hash to
+    /// the same value.
+    fn equivalent(&self, key: &K) -> bool;
+}
+
+impl<Q: ?Sized, K: ?Sized> Equivalent<K> for Q
+where
+    Q: Eq,
+    K: core::borrow::Borrow<Q>,
+{
+    fn equivalent(&self, key: &K) -> bool {
+        self == key.borrow()
+    }
+}
+
 /// The error type for `try_reserve` methods.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum TryReserveError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub use crate::set::HashSet;
 /// Key equivalence trait.
 ///
 /// This trait defines the function used to compare the input value with the
-/// map keys (or set values) during a lookup operation sur as [`HashMap::get`]
+/// map keys (or set values) during a lookup operation such as [`HashMap::get`]
 /// or [`HashSet::contains`].
 /// It is provided with a blanket implementation based on the
 /// [`Borrow`](core::borrow::Borrow) trait.
@@ -131,7 +131,7 @@ pub use crate::set::HashSet;
 pub trait Equivalent<K: ?Sized> {
     /// Checks if this value is equivalent to the given key.
     ///
-    /// Returns `true` if oth values are equivalent, and `false` otherwise.
+    /// Returns `true` if both values are equivalent, and `false` otherwise.
     ///
     /// # Correctness
     ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -252,9 +252,8 @@ where
 
 #[cfg(feature = "nightly")]
 #[cfg_attr(feature = "inline-more", inline)]
-pub(crate) fn make_hash<K, Q, S>(hash_builder: &S, val: &Q) -> u64
+pub(crate) fn make_hash<Q, S>(hash_builder: &S, val: &Q) -> u64
 where
-    K: Borrow<Q>,
     Q: Hash + ?Sized,
     S: BuildHasher,
 {
@@ -8255,7 +8254,7 @@ mod test_map {
                             let e = map.table.insert(
                                 hash_value,
                                 (i, 2 * i),
-                                super::make_hasher::<usize, _, usize, _>(&hash_builder),
+                                super::make_hasher::<_, usize, _>(&hash_builder),
                             );
                             it.reflect_insert(&e);
                             if let Some(p) = removed.iter().position(|e| e == &(i, 2 * i)) {

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,6 +1,5 @@
-use crate::TryReserveError;
+use crate::{Equivalent, TryReserveError};
 use alloc::borrow::ToOwned;
-use core::borrow::Borrow;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::iter::{Chain, FromIterator, FusedIterator};
@@ -773,8 +772,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
     where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Equivalent<T>,
     {
         self.map.contains_key(value)
     }
@@ -800,8 +798,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
     where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Equivalent<T>,
     {
         // Avoid `Option::map` because it bloats LLVM IR.
         match self.map.get_key_value(value) {
@@ -856,8 +853,7 @@ where
     #[inline]
     pub fn get_or_insert_owned<Q: ?Sized>(&mut self, value: &Q) -> &T
     where
-        T: Borrow<Q>,
-        Q: Hash + Eq + ToOwned<Owned = T>,
+        Q: Hash + Equivalent<T> + ToOwned<Owned = T>,
     {
         // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
         // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
@@ -889,8 +885,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
     where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Equivalent<T>,
         F: FnOnce(&Q) -> T,
     {
         // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
@@ -1106,8 +1101,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
     where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Equivalent<T>,
     {
         self.map.remove(value).is_some()
     }
@@ -1133,8 +1127,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
     where
-        T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Equivalent<T>,
     {
         // Avoid `Option::map` because it bloats LLVM IR.
         match self.map.remove_entry(value) {

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -1,0 +1,53 @@
+use hashbrown::Equivalent;
+use hashbrown::HashMap;
+
+use std::hash::Hash;
+
+#[derive(Debug, Hash)]
+pub struct Pair<A, B>(pub A, pub B);
+
+impl<A, B, C, D> PartialEq<(A, B)> for Pair<C, D>
+where
+    C: PartialEq<A>,
+    D: PartialEq<B>,
+{
+    fn eq(&self, rhs: &(A, B)) -> bool {
+        self.0 == rhs.0 && self.1 == rhs.1
+    }
+}
+
+impl<A, B, X> Equivalent<X> for Pair<A, B>
+where
+    Pair<A, B>: PartialEq<X>,
+    A: Hash + Eq,
+    B: Hash + Eq,
+{
+    fn equivalent(&self, other: &X) -> bool {
+        *self == *other
+    }
+}
+
+#[test]
+fn test_lookup() {
+    let s = String::from;
+    let mut map = HashMap::new();
+    map.insert((s("a"), s("b")), 1);
+    map.insert((s("a"), s("x")), 2);
+
+    assert!(map.contains_key(&Pair("a", "b")));
+    assert!(!map.contains_key(&Pair("b", "a")));
+}
+
+#[test]
+fn test_string_str() {
+    let s = String::from;
+    let mut map = HashMap::new();
+    map.insert(s("a"), 1);
+    map.insert(s("b"), 2);
+    map.insert(s("x"), 3);
+    map.insert(s("y"), 4);
+
+    assert!(map.contains_key("a"));
+    assert!(!map.contains_key("z"));
+    assert_eq!(map.remove("b"), Some(2));
+}


### PR DESCRIPTION
This PR introduces an `Equivalent` trait, as requested in #345, to customize lookup operations without requiring a `Borrow` implementation. It provides a blanket implementation that covers the `Borrow` case so it should not break anything.

The `hash_map::EntryRef` API, although it uses the `Borrow` trait, remains unchanged as this would introduce some breaking changes.