### PR TITLE
Add an `into_ref` method, an immutable version of the `into_mut` method

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -3587,6 +3587,27 @@ impl<'a, K, V, S, A: Allocator + Clone> RawOccupiedEntryMut<'a, K, V, S, A> {
         unsafe { &self.elem.as_ref().1 }
     }
 
+    /// Converts the OccupiedEntry into an immutable reference to the value in the entry
+    /// with a lifetime bound to the map itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn my_poneyland<'a>(map: &'a mut HashMap<&str, u32>) -> &'a u32 {
+    ///     map.entry("poneyland").insert(12).into_ref()
+    /// }
+    ///
+    /// assert_eq!(my_poneyland(&mut map), &12);
+    /// ```
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn into_ref(self) -> &'a V {
+        unsafe { &self.elem.as_ref().1 }
+    }
+
     /// Converts the OccupiedEntry into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
     ///
@@ -5252,6 +5273,27 @@ impl<'a, K, V, S, A: Allocator + Clone> OccupiedEntry<'a, K, V, S, A> {
         unsafe { &mut self.elem.as_mut().1 }
     }
 
+    /// Converts the OccupiedEntry into an immutable reference to the value in the entry
+    /// with a lifetime bound to the map itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn my_poneyland<'a>(map: &'a mut HashMap<&str, u32>) -> &'a u32 {
+    ///     map.entry("poneyland").insert(12).into_ref()
+    /// }
+    ///
+    /// assert_eq!(my_poneyland(&mut map), &12);
+    /// ```
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn into_ref(self) -> &'a V {
+        unsafe { &self.elem.as_ref().1 }
+    }
+
     /// Converts the OccupiedEntry into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
     ///
@@ -5981,6 +6023,27 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> OccupiedEntryRef<'a, 'b, 
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_mut(&mut self) -> &mut V {
         unsafe { &mut self.elem.as_mut().1 }
+    }
+
+    /// Converts the OccupiedEntryRef into an immutable reference to the value in the entry
+    /// with a lifetime bound to the map itself.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn my_poneyland<'a>(map: &'a mut HashMap<&str, u32>) -> &'a u32 {
+    ///     map.entry_ref("poneyland").insert(12).into_ref()
+    /// }
+    ///
+    /// assert_eq!(my_poneyland(&mut map), &12);
+    /// ```
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn into_ref(self) -> &'a V {
+        unsafe { &self.elem.as_ref().1 }
     }
 
     /// Converts the OccupiedEntryRef into a mutable reference to the value in the entry

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -428,7 +428,7 @@ impl<'a, K, V, A: Allocator + Clone> RustcOccupiedEntry<'a, K, V, A> {
     ///
     /// let mut map: HashMap<&str, u32> = HashMap::new();
     ///
-    /// fn my_poneyland(map: &mut HashMap<&str, u32>) -> &u32 {
+    /// fn my_poneyland<'a>(map: &'a mut HashMap<&str, u32>) -> &'a u32 {
     ///     map.rustc_entry("poneyland").insert(12).into_ref()
     /// }
     ///

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -413,6 +413,32 @@ impl<'a, K, V, A: Allocator + Clone> RustcOccupiedEntry<'a, K, V, A> {
         unsafe { &mut self.elem.as_mut().1 }
     }
 
+    /// Converts the RustcOccupiedEntry into an immutable reference to the value in the entry
+    /// with a lifetime bound to the map itself.
+    ///
+    /// If you need multiple references to the `RustcOccupiedEntry`, see [`get`].
+    ///
+    /// [`get`]: #method.get
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::RustcEntry;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn my_poneyland(map: &mut HashMap<&str, u32>) -> &u32 {
+    ///     map.rustc_entry("poneyland").insert(12).into_ref()
+    /// }
+    ///
+    /// assert_eq!(my_poneyland(&mut map), &12);
+    /// ```
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn into_ref(self) -> &'a V {
+        unsafe { &self.elem.as_ref().1 }
+    }
+
     /// Sets the value of the entry, and returns the entry's old value.
     ///
     /// # Examples


### PR DESCRIPTION
Was looking around for a way to return the reference from a function that inserts it using the entry and am currently just using the `into_mut()` because it will just coerce down into a `&'a V` anyways. But would be nice to have the type safety of it.