### PR TITLE
add support for architectures with 16-bit pointer width Closes #352

### DIFF
--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -19,8 +19,8 @@ type GroupWord = u64;
     not(target_arch = "wasm32"),
 ))]
 type GroupWord = u32;
-#[cfg(target_pointer_width="16")]
-type GroupWord=u16;
+#[cfg(target_pointer_width = "16")]
+type GroupWord = u16;
 
 pub type BitMaskWord = GroupWord;
 pub const BITMASK_STRIDE: usize = 8;

--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -19,6 +19,8 @@ type GroupWord = u64;
     not(target_arch = "wasm32"),
 ))]
 type GroupWord = u32;
+#[cfg(target_pointer_width="16")]
+type GroupWord=u16;
 
 pub type BitMaskWord = GroupWord;
 pub const BITMASK_STRIDE: usize = 8;


### PR DESCRIPTION
One example is AVR-based microcontrollers like the atmega328 or atmega2560