### PR TITLE
make with_hasher_in const (consistent with with_hasher)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           thumbv6m-none-eabi,
           x86_64-pc-windows-gnu,
         ]
-        channel: [1.58.1, nightly]
+        channel: [1.61.0, nightly]
         include:
         - os: macos-latest
           target: x86_64-apple-darwin
@@ -60,13 +60,13 @@ jobs:
           channel: nightly
         - os: macos-latest
           target: x86_64-apple-darwin
-          channel: 1.58.1
+          channel: 1.61.0
         - os: windows-latest
           target: x86_64-pc-windows-msvc
-          channel: 1.58.1
+          channel: 1.61.0
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          channel: 1.56.1
+          channel: 1.61.0
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           channel: beta

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hashbrown
 [![Build Status](https://github.com/rust-lang/hashbrown/actions/workflows/rust.yml/badge.svg)](https://github.com/rust-lang/hashbrown/actions)
 [![Crates.io](https://img.shields.io/crates/v/hashbrown.svg)](https://crates.io/crates/hashbrown)
 [![Documentation](https://docs.rs/hashbrown/badge.svg)](https://docs.rs/hashbrown)
-[![Rust](https://img.shields.io/badge/rust-1.56.1%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
+[![Rust](https://img.shields.io/badge/rust-1.61.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
 
 This crate is a Rust port of Google's high-performance [SwissTable] hash
 map, adapted to make it a drop-in replacement for Rust's standard `HashMap`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
     feature = "nightly",
     feature(
         test,
-        const_fn_trait_bound,
         core_intrinsics,
         dropck_eyepatch,
         min_specialization,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
     feature = "nightly",
     feature(
         test,
+        const_fn_trait_bound,
         core_intrinsics,
         dropck_eyepatch,
         min_specialization,

--- a/src/map.rs
+++ b/src/map.rs
@@ -429,7 +429,8 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// Creates an empty `HashMap` which will use the given hash builder to hash
     /// keys. It will be allocated with the given allocator.
     ///
-    /// The created map has the default initial capacity.
+    /// The hash map is initially created with a capacity of 0, so it will not
+    /// allocate until it is first inserted into.
     ///
     /// Warning: `hash_builder` is normally randomly generated, and
     /// is designed to allow HashMaps to be resistant to attacks that
@@ -447,7 +448,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// map.insert(1, 2);
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn with_hasher_in(hash_builder: S, alloc: A) -> Self {
+    pub const fn with_hasher_in(hash_builder: S, alloc: A) -> Self {
         Self {
             hash_builder,
             table: RawTable::new_in(alloc),

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -426,7 +426,7 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// leave the data pointer dangling since that bucket is never written to
     /// due to our load factor forcing us to always have at least 1 free bucket.
     #[inline]
-    pub fn new_in(alloc: A) -> Self {
+    pub const fn new_in(alloc: A) -> Self {
         Self {
             table: RawTableInner::new_in(alloc),
             marker: PhantomData,

--- a/src/set.rs
+++ b/src/set.rs
@@ -387,7 +387,8 @@ impl<T, S> HashSet<T, S, Global> {
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
     ///
-    /// The hash set is also created with the default initial capacity.
+    /// The hash set is initially created with a capacity of 0, so it will not
+    /// allocate until it is first inserted into.
     ///
     /// Warning: `hasher` is normally randomly generated, and
     /// is designed to allow `HashSet`s to be resistant to attacks that
@@ -464,7 +465,8 @@ where
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
     ///
-    /// The hash set is also created with the default initial capacity.
+    /// The hash set is initially created with a capacity of 0, so it will not
+    /// allocate until it is first inserted into.
     ///
     /// Warning: `hasher` is normally randomly generated, and
     /// is designed to allow `HashSet`s to be resistant to attacks that
@@ -482,7 +484,7 @@ where
     /// set.insert(2);
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn with_hasher_in(hasher: S, alloc: A) -> Self {
+    pub const fn with_hasher_in(hasher: S, alloc: A) -> Self {
         Self {
             map: HashMap::with_hasher_in(hasher, alloc),
         }


### PR DESCRIPTION
I found that the following four methods have additional comments about their allocation:

* HashMap::with_hasher
* HashMap::with_hasher_in
* HashSet::with_hasher
* HashSet::with_hasher_in

There is no reason to make such a difference; in this PR, I make them consistent as the following behavior:

* All methods clarify that they will not allocate memory before the first insertion
* All methods are marked as const function.

We also bump the MSRV to 1.61.0 for the const_fn_trait_bound feature. Currently, 1.64.0 has been released, and I guess it's acceptable to break the 1.61.0 users.

Signed-off-by: TennyZhuang <zty0826@gmail.com>