### PR TITLE
Upgrade to ahash 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.7.0", default-features = false, optional = true }
+ahash = { version = "0.8.0", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }
@@ -39,7 +39,6 @@ doc-comment = "0.3.1"
 [features]
 default = ["ahash", "inline-more"]
 
-ahash-compile-time-rng = ["ahash/compile-time-rng"]
 nightly = []
 rustc-internal-api = []
 rustc-dep-of-std = [

--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ This crate has the following Cargo features:
   of compilation time. (enabled by default)
 - `bumpalo`: Provides a `BumpWrapper` type which allows `bumpalo` to be used for memory allocation.
 - `ahash`: Compiles with ahash as default hasher. (enabled by default)
-- `ahash-compile-time-rng`: Activates the `compile-time-rng` feature of ahash. For targets with no random number generator
-this pre-generates seeds at compile time and embeds them as constants. See [aHash's documentation](https://github.com/tkaitchuck/aHash#flags) (disabled by default)
 
 ## License
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use core::ops::Index;
 
 /// Default hasher for `HashMap`.
 #[cfg(feature = "ahash")]
-pub type DefaultHashBuilder = ahash::RandomState;
+pub type DefaultHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
 
 /// Dummy default hasher for `HashMap`.
 #[cfg(not(feature = "ahash"))]


### PR DESCRIPTION
This changes the default hasher to use a fixed key by default and removes the dependency on `getrandom`. This is fine since hashbrown has never made any guarantees about HashDoS resistance in its default hasher.

Users who require HashDoS resistance should explicitly use `ahash::RandomState` or `std::collections::hash_map::RandomState` as the hasher when creating a `HashMap`.

Fixes #356