### PR TITLE
Add HashSet#raw_table

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1996,7 +1996,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     ///
     /// # Note
     ///
-    /// Calling the function safe, but using raw hash table API's may require
+    /// Calling this function is safe, but using the raw hash table API may require
     /// unsafe functions or blocks.
     ///
     /// `RawTable` API gives the lowest level of control under the map that can be useful

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "raw")]
+use crate::raw::RawTable;
 use crate::{Equivalent, TryReserveError};
 use alloc::borrow::ToOwned;
 use core::fmt;
@@ -1134,6 +1136,26 @@ where
             Some((k, _)) => Some(k),
             None => None,
         }
+    }
+
+    /// Returns a mutable reference to the [`RawTable`] used underneath [`HashSet`].
+    /// This function is only available if the `raw` feature of the crate is enabled.
+    ///
+    /// # Note
+    ///
+    /// Calling the function safe, but using raw hash table API's may require
+    /// unsafe functions or blocks.
+    ///
+    /// `RawTable` API gives the lowest level of control under the set that can be useful
+    /// for extending the HashSet's API, but may lead to *[undefined behavior]*.
+    ///
+    /// [`HashSet`]: struct.HashSet.html
+    /// [`RawTable`]: raw/struct.RawTable.html
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+    #[cfg(feature = "raw")]
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn raw_table(&mut self) -> &mut RawTable<(T, ()), A> {
+        self.map.raw_table()
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1143,7 +1143,7 @@ where
     ///
     /// # Note
     ///
-    /// Calling the function safe, but using raw hash table API's may require
+    /// Calling this function is safe, but using the raw hash table API may require
     /// unsafe functions or blocks.
     ///
     /// `RawTable` API gives the lowest level of control under the set that can be useful


### PR DESCRIPTION
Just like #335 did for `HashMap`, I'd like to add access to the underlying `RawTable` for `HashSet`. I intend to use it in conjunction with #354 to pull random elements from a `HashSet`.

Let me know if I've missed something here or you'd like things implemented differently. I'll be happy to change it up!