### PR TITLE
Documentation fix due to latest changes in the crate.

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -290,7 +290,9 @@ impl<K, V> HashMap<K, V, DefaultHashBuilder> {
     /// The hash map is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -318,7 +320,9 @@ impl<K, V> HashMap<K, V, DefaultHashBuilder> {
     /// The hash map will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -349,7 +353,9 @@ impl<K, V, A: Allocator + Clone> HashMap<K, V, DefaultHashBuilder, A> {
     /// The hash map is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -398,7 +404,9 @@ impl<K, V, A: Allocator + Clone> HashMap<K, V, DefaultHashBuilder, A> {
     /// The hash map will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -455,7 +463,9 @@ impl<K, V, S> HashMap<K, V, S> {
     /// The hash map is initially created with a capacity of 0, so it will not
     /// allocate until it is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -495,7 +505,9 @@ impl<K, V, S> HashMap<K, V, S> {
     /// The hash map will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -543,7 +555,9 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// The hash map is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -576,7 +590,9 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// The hash map will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -6193,7 +6209,7 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> OccupiedEntryRef<'a, 'b, 
     ///
     /// # Panics
     ///
-    /// Will panic if this OccupiedEntryRef was created through [`Entry::insert`].
+    /// Will panic if this OccupiedEntryRef was created through [`EntryRef::insert`].
     ///
     /// # Examples
     ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -291,7 +291,7 @@ impl<K, V> HashMap<K, V, DefaultHashBuilder> {
     /// is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -321,7 +321,7 @@ impl<K, V> HashMap<K, V, DefaultHashBuilder> {
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -354,7 +354,7 @@ impl<K, V, A: Allocator + Clone> HashMap<K, V, DefaultHashBuilder, A> {
     /// is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -405,7 +405,7 @@ impl<K, V, A: Allocator + Clone> HashMap<K, V, DefaultHashBuilder, A> {
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -464,7 +464,7 @@ impl<K, V, S> HashMap<K, V, S> {
     /// allocate until it is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -506,7 +506,7 @@ impl<K, V, S> HashMap<K, V, S> {
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -556,7 +556,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -591,7 +591,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// reallocating. If `capacity` is 0, the hash map will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashMap` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use

--- a/src/set.rs
+++ b/src/set.rs
@@ -136,7 +136,9 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -164,7 +166,9 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -196,7 +200,9 @@ impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -224,7 +230,9 @@ impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -430,7 +438,9 @@ impl<T, S> HashSet<T, S, Global> {
     /// The hash set is initially created with a capacity of 0, so it will not
     /// allocate until it is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -466,7 +476,9 @@ impl<T, S> HashSet<T, S, Global> {
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -513,7 +525,9 @@ where
     /// The hash set is initially created with a capacity of 0, so it will not
     /// allocate until it is first inserted into.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
@@ -549,7 +563,9 @@ where
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
-    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// # HashDoS resistance
+    /// 
+    /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
     /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]

--- a/src/set.rs
+++ b/src/set.rs
@@ -136,6 +136,16 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`], for example with
+    /// [`with_hasher`](HashSet::with_hasher) method.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
+    ///
     /// # Examples
     ///
     /// ```
@@ -153,6 +163,16 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     ///
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
+    ///
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`], for example with
+    /// [`with_capacity_and_hasher`](HashSet::with_capacity_and_hasher) method.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
     ///
     /// # Examples
     ///
@@ -176,6 +196,16 @@ impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     /// The hash set is initially created with a capacity of 0, so it will not allocate until it
     /// is first inserted into.
     ///
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`], for example with
+    /// [`with_hasher_in`](HashSet::with_hasher_in) method.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
+    ///
     /// # Examples
     ///
     /// ```
@@ -193,6 +223,16 @@ impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     ///
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
+    ///
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`], for example with
+    /// [`with_capacity_and_hasher_in`](HashSet::with_capacity_and_hasher_in) method.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
     ///
     /// # Examples
     ///
@@ -387,16 +427,21 @@ impl<T, S> HashSet<T, S, Global> {
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
     ///
-    /// The hash set is also created with the default initial capacity.
+    /// The hash set is initially created with a capacity of 0, so it will not
+    /// allocate until it is first inserted into.
     ///
-    /// Warning: `hasher` is normally randomly generated, and
-    /// is designed to allow `HashSet`s to be resistant to attacks that
-    /// cause many collisions and very poor performance. Setting it
-    /// manually using this function can expose a DoS attack vector.
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`].
     ///
     /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
-    /// the HashMap to be useful, see its documentation for details.
+    /// the HashSet to be useful, see its documentation for details.
     ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
+    /// [`BuildHasher`]: https://doc.rust-lang.org/std/hash/trait.BuildHasher.html
     ///
     /// # Examples
     ///
@@ -408,8 +453,6 @@ impl<T, S> HashSet<T, S, Global> {
     /// let mut set = HashSet::with_hasher(s);
     /// set.insert(2);
     /// ```
-    ///
-    /// [`BuildHasher`]: ../../std/hash/trait.BuildHasher.html
     #[cfg_attr(feature = "inline-more", inline)]
     pub const fn with_hasher(hasher: S) -> Self {
         Self {
@@ -423,13 +466,18 @@ impl<T, S> HashSet<T, S, Global> {
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
-    /// Warning: `hasher` is normally randomly generated, and
-    /// is designed to allow `HashSet`s to be resistant to attacks that
-    /// cause many collisions and very poor performance. Setting it
-    /// manually using this function can expose a DoS attack vector.
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`].
     ///
     /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
-    /// the HashMap to be useful, see its documentation for details.
+    /// the HashSet to be useful, see its documentation for details.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
+    /// [`BuildHasher`]: https://doc.rust-lang.org/std/hash/trait.BuildHasher.html
     ///
     /// # Examples
     ///
@@ -441,8 +489,6 @@ impl<T, S> HashSet<T, S, Global> {
     /// let mut set = HashSet::with_capacity_and_hasher(10, s);
     /// set.insert(1);
     /// ```
-    ///
-    /// [`BuildHasher`]: ../../std/hash/trait.BuildHasher.html
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> Self {
         Self {
@@ -464,12 +510,21 @@ where
     /// Creates a new empty hash set which will use the given hasher to hash
     /// keys.
     ///
-    /// The hash set is also created with the default initial capacity.
+    /// The hash set is initially created with a capacity of 0, so it will not
+    /// allocate until it is first inserted into.
     ///
-    /// Warning: `hasher` is normally randomly generated, and
-    /// is designed to allow `HashSet`s to be resistant to attacks that
-    /// cause many collisions and very poor performance. Setting it
-    /// manually using this function can expose a DoS attack vector.
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`].
+    ///
+    /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
+    /// the HashSet to be useful, see its documentation for details.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
+    /// [`BuildHasher`]: https://doc.rust-lang.org/std/hash/trait.BuildHasher.html
     ///
     /// # Examples
     ///
@@ -494,10 +549,18 @@ where
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
-    /// Warning: `hasher` is normally randomly generated, and
-    /// is designed to allow `HashSet`s to be resistant to attacks that
-    /// cause many collisions and very poor performance. Setting it
-    /// manually using this function can expose a DoS attack vector.
+    /// Warning: `hash_builder` normally use a fixed key by default and that does
+    /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
+    /// Users who require HashDoS resistance should explicitly use
+    /// [`ahash::RandomState`] or [`std::collections::hash_map::RandomState`]
+    /// as the hasher when creating a [`HashSet`].
+    ///
+    /// The `hash_builder` passed should implement the [`BuildHasher`] trait for
+    /// the HashSet to be useful, see its documentation for details.
+    ///
+    /// [`HashDoS`]: https://en.wikipedia.org/wiki/Collision_attack
+    /// [`std::collections::hash_map::RandomState`]: https://doc.rust-lang.org/std/collections/hash_map/struct.RandomState.html
+    /// [`BuildHasher`]: https://doc.rust-lang.org/std/hash/trait.BuildHasher.html
     ///
     /// # Examples
     ///
@@ -548,7 +611,12 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if the new allocation size overflows `usize`.
+    /// Panics if the new capacity exceeds [`isize::MAX`] bytes and [`abort`] the program
+    /// in case of allocation error. Use [`try_reserve`](HashSet::try_reserve) instead
+    /// if you want to handle memory allocation failure.
+    ///
+    /// [`isize::MAX`]: https://doc.rust-lang.org/std/primitive.isize.html
+    /// [`abort`]: https://doc.rust-lang.org/alloc/alloc/fn.handle_alloc_error.html
     ///
     /// # Examples
     ///
@@ -1150,7 +1218,7 @@ where
     /// for extending the HashSet's API, but may lead to *[undefined behavior]*.
     ///
     /// [`HashSet`]: struct.HashSet.html
-    /// [`RawTable`]: raw/struct.RawTable.html
+    /// [`RawTable`]: crate::raw::RawTable
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[cfg(feature = "raw")]
     #[cfg_attr(feature = "inline-more", inline)]

--- a/src/set.rs
+++ b/src/set.rs
@@ -137,7 +137,7 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     /// is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -167,7 +167,7 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -201,7 +201,7 @@ impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     /// is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -231,7 +231,7 @@ impl<T: Hash + Eq, A: Allocator + Clone> HashSet<T, DefaultHashBuilder, A> {
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -439,7 +439,7 @@ impl<T, S> HashSet<T, S, Global> {
     /// allocate until it is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -477,7 +477,7 @@ impl<T, S> HashSet<T, S, Global> {
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -526,7 +526,7 @@ where
     /// allocate until it is first inserted into.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use
@@ -564,7 +564,7 @@ where
     /// reallocating. If `capacity` is 0, the hash set will not allocate.
     ///
     /// # HashDoS resistance
-    /// 
+    ///
     /// The `hash_builder` normally use a fixed key by default and that does
     /// not allow the `HashSet` to be protected against attacks such as [`HashDoS`].
     /// Users who require HashDoS resistance should explicitly use


### PR DESCRIPTION
Due to merged PR #357, #362 I think that we need to fix docummentation.

 Fixed broken links in `HashMap::raw_table` and `HashSet::raw_table`, as well as some typos and mistakes elsewhere (especially in `EntryRef::or_insert_with_key`).

To fix #349, I removed capacity comparisons in all places (except `drain` and `clear`),  however left the phrase "keeps the allocated memory for reuse", because although the `erase` method may not release the capacity, the subsequent `rehash_in_place` function definitely will release all.

Close #349.