### PR TITLE
Make `mem::size_of::<T>() == 0, TableLayout::new::<T>() and mem::needs_drop::<T>()` const

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -296,9 +296,11 @@ impl<T> Clone for Bucket<T> {
 }
 
 impl<T> Bucket<T> {
+    const IS_ZERO_SIZED_TYPE: bool = mem::size_of::<T>() == 0;
+
     #[inline]
     unsafe fn from_base_index(base: NonNull<T>, index: usize) -> Self {
-        let ptr = if mem::size_of::<T>() == 0 {
+        let ptr = if Self::IS_ZERO_SIZED_TYPE {
             // won't overflow because index must be less than length
             (index + 1) as *mut T
         } else {
@@ -310,7 +312,7 @@ impl<T> Bucket<T> {
     }
     #[inline]
     unsafe fn to_base_index(&self, base: NonNull<T>) -> usize {
-        if mem::size_of::<T>() == 0 {
+        if Self::IS_ZERO_SIZED_TYPE {
             self.ptr.as_ptr() as usize - 1
         } else {
             offset_from(base.as_ptr(), self.ptr.as_ptr())
@@ -318,7 +320,7 @@ impl<T> Bucket<T> {
     }
     #[inline]
     pub fn as_ptr(&self) -> *mut T {
-        if mem::size_of::<T>() == 0 {
+        if Self::IS_ZERO_SIZED_TYPE {
             // Just return an arbitrary ZST pointer which is properly aligned
             mem::align_of::<T>() as *mut T
         } else {
@@ -327,7 +329,7 @@ impl<T> Bucket<T> {
     }
     #[inline]
     unsafe fn next_n(&self, offset: usize) -> Self {
-        let ptr = if mem::size_of::<T>() == 0 {
+        let ptr = if Self::IS_ZERO_SIZED_TYPE {
             (self.ptr.as_ptr() as usize + offset) as *mut T
         } else {
             self.ptr.as_ptr().sub(offset)

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -134,6 +134,13 @@ fn h1(hash: u64) -> usize {
     hash as usize
 }
 
+// Constant for h2 function that grabing the top 7 bits of the hash.
+const MIN_HASH_LEN: usize = if mem::size_of::<usize>() < mem::size_of::<u64>() {
+    mem::size_of::<usize>()
+} else {
+    mem::size_of::<u64>()
+};
+
 /// Secondary hash function, saved in the low 7 bits of the control byte.
 #[inline]
 #[allow(clippy::cast_possible_truncation)]
@@ -141,8 +148,8 @@ fn h2(hash: u64) -> u8 {
     // Grab the top 7 bits of the hash. While the hash is normally a full 64-bit
     // value, some hash functions (such as FxHash) produce a usize result
     // instead, which means that the top 32 bits are 0 on 32-bit platforms.
-    let hash_len = usize::min(mem::size_of::<usize>(), mem::size_of::<u64>());
-    let top7 = hash >> (hash_len * 8 - 7);
+    // So we use MIN_HASH_LEN constant to handle this.
+    let top7 = hash >> (MIN_HASH_LEN * 8 - 7);
     (top7 & 0x7f) as u8 // truncation
 }
 


### PR DESCRIPTION
Just preparation for the upcoming for "Add new MIR constant propagation based on dataflow analysis" https://github.com/rust-lang/rust/pull/101168, but this change is also useful on its own.