### PR TITLE
Rewrite `get_many_mut` methods

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1730,9 +1730,15 @@ where
     where
         Q: Hash + Equivalent<K>,
     {
-        let hashes = self.build_hashes_inner(ks);
-        self.table
-            .get_many_mut(hashes, |i, (k, _)| ks[i].equivalent(k))
+        let hash_builder = &self.hash_builder;
+
+        let mut iter = ks.into_iter().map(|key| {
+            (
+                make_hash::<Q, S>(hash_builder, key),
+                equivalent_key::<Q, K, V>(key),
+            )
+        });
+        self.table.get_many_mut_from_iter(&mut iter)
     }
 
     unsafe fn get_many_unchecked_mut_inner<Q: ?Sized, const N: usize>(
@@ -1742,20 +1748,15 @@ where
     where
         Q: Hash + Equivalent<K>,
     {
-        let hashes = self.build_hashes_inner(ks);
-        self.table
-            .get_many_unchecked_mut(hashes, |i, (k, _)| ks[i].equivalent(k))
-    }
+        let hash_builder = &self.hash_builder;
 
-    fn build_hashes_inner<Q: ?Sized, const N: usize>(&self, ks: [&Q; N]) -> [u64; N]
-    where
-        Q: Hash + Equivalent<K>,
-    {
-        let mut hashes = [0_u64; N];
-        for i in 0..N {
-            hashes[i] = make_hash::<Q, S>(&self.hash_builder, ks[i]);
-        }
-        hashes
+        let mut iter = ks.into_iter().map(|key| {
+            (
+                make_hash::<Q, S>(hash_builder, key),
+                equivalent_key::<Q, K, V>(key),
+            )
+        });
+        self.table.get_many_unchecked_mut_from_iter(&mut iter)
     }
 
     /// Inserts a key-value pair into the map.

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1044,11 +1044,11 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
         // stable
         let mut array = unsafe { MaybeUninit::<[MaybeUninit<*mut T>; N]>::uninit().assume_init() };
 
-        for elememt in &mut array {
+        for element in &mut array {
             match iter.next() {
                 Some((hash, eq)) => match self.find(hash, eq) {
                     Some(bucket) => {
-                        elememt.write(bucket.as_ptr());
+                        element.write(bucket.as_ptr());
                     }
                     None => return None,
                 },


### PR DESCRIPTION
The previous form of the `HashMap::get_many_mut_inner` and `HashMap::get_many_unchecked_mut_inner` functions was not very optimal:

- firstly, the old RawTable API was not very convenient and did not combine well with each other (`get_mut` requires that `eq: impl FnMut(&T) -> bool`, get_many_mut requires that `eq` argument should be a closure such that `eq(i, k)` returns true if `k` is equal to the `i`th key to be looked up.).
- secondly, the hash of all keys was calculated, regardless of whether there are any of given keys in the table at all.