### PR TITLE
changelog: Fix heading levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v0.13.1] - 2022-11-10
 
-# Added
+### Added
 
 - Added `Equivalent` trait to customize key lookups. (#350)
 - Added support for 16-bit targets. (#368)
 - Added `RawTable::allocation_info` which provides information about the memory
   usage of a table. (#371)
 
-# Changed
+### Changed
 
 - Bumped MSRV to 1.61.0.
 - Upgraded to `ahash` 0.8. (#357)
@@ -28,40 +28,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   - `Bucket::drop` => Use `RawTable::erase` instead.
   - `Bucket::write` => Use `Bucket::as_mut` instead.
 
-# Fixed
+### Fixed
 
 - Ensure that `HashMap` allocations don't exceed `isize::MAX`. (#362)
 - Fixed issue with field retagging in scopeguard. (#359)
 
 ## [v0.12.3] - 2022-07-17
 
-## Fixed
+### Fixed
 
 - Fixed double-drop in `RawTable::clone_from`. (#348)
 
 ## [v0.12.2] - 2022-07-09
 
-## Added
+### Added
 
 - Added `Entry` API for `HashSet`. (#342)
 - Added `Extend<&'a (K, V)> for HashMap<K, V, S, A>`. (#340)
 - Added length-based short-circuiting for hash table iteration. (#338)
 - Added a function to access the `RawTable` of a `HashMap`. (#335)
 
-## Changed
+### Changed
 
 - Edited `do_alloc` to reduce LLVM IR generated. (#341)
 
 ## [v0.12.1] - 2022-05-02
 
-## Fixed
+### Fixed
 
 - Fixed underflow in `RawIterRange::size_hint`. (#325)
 - Fixed the implementation of `Debug` for `ValuesMut` and `IntoValues`. (#325)
 
 ## [v0.12.0] - 2022-01-17
 
-## Added
+### Added
 
 - Added `From<[T; N]>` and `From<[(K, V); N]>` for `HashSet` and `HashMap` respectively. (#297)
 - Added an `allocator()` getter to HashMap and HashSet. (#257)
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Implement `From<array>` on `HashSet` and `HashMap`. (#298)
 - Added `entry_ref` API to `HashMap`. (#201)
 
-## Changed
+### Changed
 
 - Bumped minimum Rust version to 1.56.1 and edition to 2021.
 - Use u64 for the GroupWord on WebAssembly. (#271)
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Rename `get_each_mut` to `get_many_mut` and align API with the stdlib. (#291)
 - Don't hash the key when searching in an empty table. (#305)
 
-## Fixed
+### Fixed
 
 - Guard against allocations exceeding isize::MAX. (#268)
 - Made `RawTable::insert_no_grow` unsafe. (#254)
@@ -91,19 +91,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v0.11.2] - 2021-03-25
 
-## Fixed
+### Fixed
 
 - Added missing allocator type parameter to `HashMap`'s and `HashSet`'s `Clone` impls. (#252)
 
 ## [v0.11.1] - 2021-03-20
 
-## Fixed
+### Fixed
 
 - Added missing `pub` modifier to `BumpWrapper`. (#251)
 
 ## [v0.11.0] - 2021-03-14
 
-## Added
+### Added
 - Added safe `try_insert_no_grow` method to `RawTable`. (#229)
 - Added support for `bumpalo` as an allocator without the `nightly` feature. (#231)
 - Implemented `Default` for `RawTable`. (#237)
@@ -112,22 +112,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added `From<HashMap<T, ()>>` for `HashSet<T>`. (#235)
 - Added `try_insert` method to `HashMap`. (#247)
 
-## Changed
+### Changed
 - The minimum Rust version has been bumped to 1.49.0. (#230)
 - Significantly improved compilation times by reducing the amount of generated IR. (#205)
 
-## Removed
+### Removed
 - We no longer re-export the unstable allocator items from the standard library, nor the stable shims approximating the same. (#227)
 - Removed hasher specialization support from `aHash`, which was resulting in inconsistent hashes being generated for a key. (#248)
 
-## Fixed
+### Fixed
 - Fixed union length comparison. (#228)
 
 ## ~~[v0.10.0] - 2021-01-16~~
 
 This release was _yanked_ due to inconsistent hashes being generated with the `nightly` feature. (#248)
 
-## Changed
+### Changed
 - Parametrized `RawTable`, `HashSet` and `HashMap` over an allocator. (#133)
 - Improved branch prediction hints on stable. (#209)
 - Optimized hashing of primitive types with AHash using specialization. (#207)
@@ -135,7 +135,7 @@ This release was _yanked_ due to inconsistent hashes being generated with the `n
 
 ## [v0.9.1] - 2020-09-28
 
-## Added
+### Added
 - Added safe methods to `RawTable` (#202):
   - `get`: `find` and `as_ref`
   - `get_mut`: `find` and `as_mut`
@@ -143,7 +143,7 @@ This release was _yanked_ due to inconsistent hashes being generated with the `n
   - `remove_entry`: `find` and `remove`
   - `erase_entry`: `find` and `erase`
 
-## Changed
+### Changed
 - Removed `from_key_hashed_nocheck`'s `Q: Hash`. (#200)
 - Made `RawTable::drain` safe. (#201)
 


### PR DESCRIPTION
The "Added, Fixed and Changed" headings should be one level below the individual versions to nest them properly. This gives dependency update services (renovatebot, dependatbot, etc.) a chance to parse the changelog and extract the changes for their PRs :)