### PR TITLE
Add .rustfmt.toml with two options:

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -6,14 +6,12 @@
 
 extern crate test;
 
-use test::{black_box, Bencher};
+use std::collections::hash_map::RandomState;
+use std::sync::atomic::{self, AtomicUsize};
 
 use hashbrown::hash_map::DefaultHashBuilder;
 use hashbrown::{HashMap, HashSet};
-use std::{
-    collections::hash_map::RandomState,
-    sync::atomic::{self, AtomicUsize},
-};
+use test::{black_box, Bencher};
 
 const SIZE: usize = 1000;
 

--- a/src/external_trait_impls/rayon/map.rs
+++ b/src/external_trait_impls/rayon/map.rs
@@ -1,13 +1,15 @@
 //! Rayon extensions for `HashMap`.
 
-use super::raw::{RawIntoParIter, RawParDrain, RawParIter};
-use crate::hash_map::HashMap;
-use crate::raw::{Allocator, Global};
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::marker::PhantomData;
+
 use rayon::iter::plumbing::UnindexedConsumer;
 use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
+
+use super::raw::{RawIntoParIter, RawParDrain, RawParIter};
+use crate::hash_map::HashMap;
+use crate::raw::{Allocator, Global};
 
 /// Parallel iterator over shared references to entries in a map.
 ///

--- a/src/external_trait_impls/rayon/raw.rs
+++ b/src/external_trait_impls/rayon/raw.rs
@@ -1,14 +1,13 @@
-use crate::raw::Bucket;
-use crate::raw::{Allocator, Global, RawIter, RawIterRange, RawTable};
-use crate::scopeguard::guard;
 use alloc::alloc::dealloc;
 use core::marker::PhantomData;
 use core::mem;
 use core::ptr::NonNull;
-use rayon::iter::{
-    plumbing::{self, Folder, UnindexedConsumer, UnindexedProducer},
-    ParallelIterator,
-};
+
+use rayon::iter::plumbing::{self, Folder, UnindexedConsumer, UnindexedProducer};
+use rayon::iter::ParallelIterator;
+
+use crate::raw::{Allocator, Bucket, Global, RawIter, RawIterRange, RawTable};
+use crate::scopeguard::guard;
 
 /// Parallel iterator which returns a raw pointer to every full bucket in the table.
 pub struct RawParIter<T> {

--- a/src/external_trait_impls/rayon/set.rs
+++ b/src/external_trait_impls/rayon/set.rs
@@ -1,11 +1,13 @@
 //! Rayon extensions for `HashSet`.
 
+use core::hash::{BuildHasher, Hash};
+
+use rayon::iter::plumbing::UnindexedConsumer;
+use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
+
 use super::map;
 use crate::hash_set::HashSet;
 use crate::raw::{Allocator, Global};
-use core::hash::{BuildHasher, Hash};
-use rayon::iter::plumbing::UnindexedConsumer;
-use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
 
 /// Parallel iterator over elements of a consumed set.
 ///

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -14,12 +14,12 @@ mod map {
     use core::fmt;
     use core::hash::{BuildHasher, Hash};
     use core::marker::PhantomData;
+
     use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
     use serde::ser::{Serialize, Serializer};
 
-    use crate::hash_map::HashMap;
-
     use super::size_hint;
+    use crate::hash_map::HashMap;
 
     impl<K, V, H> Serialize for HashMap<K, V, H>
     where
@@ -92,12 +92,12 @@ mod set {
     use core::fmt;
     use core::hash::{BuildHasher, Hash};
     use core::marker::PhantomData;
+
     use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
     use serde::ser::{Serialize, Serializer};
 
-    use crate::hash_set::HashSet;
-
     use super::size_hint;
+    use crate::hash_set::HashSet;
 
     impl<T, H> Serialize for HashSet<T, H>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@ mod set;
 pub mod hash_map {
     //! A hash map implemented with quadratic probing and SIMD lookup.
     pub use crate::map::*;
-
     #[cfg(feature = "rustc-internal-api")]
     pub use crate::rustc_entry::*;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,3 @@
-use crate::raw::{Allocator, Bucket, Global, RawDrain, RawIntoIter, RawIter, RawTable};
-use crate::{Equivalent, TryReserveError};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::hash::{BuildHasher, Hash};
@@ -7,6 +5,9 @@ use core::iter::{FromIterator, FusedIterator};
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::Index;
+
+use crate::raw::{Allocator, Bucket, Global, RawDrain, RawIntoIter, RawIter, RawTable};
+use crate::{Equivalent, TryReserveError};
 
 /// Default hasher for `HashMap`.
 #[cfg(feature = "ahash")]
@@ -6700,15 +6701,16 @@ fn assert_covariance() {
 
 #[cfg(test)]
 mod test_map {
-    use super::DefaultHashBuilder;
-    use super::Entry::{Occupied, Vacant};
-    use super::EntryRef;
-    use super::{HashMap, RawEntryMut};
-    use rand::{rngs::SmallRng, Rng, SeedableRng};
     use std::borrow::ToOwned;
     use std::cell::RefCell;
     use std::usize;
     use std::vec::Vec;
+
+    use rand::rngs::SmallRng;
+    use rand::{Rng, SeedableRng};
+
+    use super::Entry::{Occupied, Vacant};
+    use super::{DefaultHashBuilder, EntryRef, HashMap, RawEntryMut};
 
     #[test]
     fn test_zero_capacities() {

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -2,9 +2,10 @@ pub(crate) use self::inner::{do_alloc, Allocator, Global};
 
 #[cfg(feature = "nightly")]
 mod inner {
+    use core::ptr::NonNull;
+
     use crate::alloc::alloc::Layout;
     pub use crate::alloc::alloc::{Allocator, Global};
-    use core::ptr::NonNull;
 
     #[allow(clippy::map_err_ignore)]
     pub fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<u8>, ()> {
@@ -30,8 +31,9 @@ mod inner {
 
 #[cfg(not(feature = "nightly"))]
 mod inner {
-    use crate::alloc::alloc::{alloc, dealloc, Layout};
     use core::ptr::NonNull;
+
+    use crate::alloc::alloc::{alloc, dealloc, Layout};
 
     #[allow(clippy::missing_safety_doc)] // not exposed outside of this crate
     pub unsafe trait Allocator {

--- a/src/raw/bitmask.rs
+++ b/src/raw/bitmask.rs
@@ -1,6 +1,7 @@
-use super::imp::{BitMaskWord, BITMASK_MASK, BITMASK_STRIDE};
 #[cfg(feature = "nightly")]
 use core::intrinsics;
+
+use super::imp::{BitMaskWord, BITMASK_MASK, BITMASK_STRIDE};
 
 /// A bit mask which contains the result of a `Match` operation on a `Group` and
 /// allows iterating through them.

--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -1,6 +1,7 @@
+use core::{mem, ptr};
+
 use super::bitmask::BitMask;
 use super::EMPTY;
-use core::{mem, ptr};
 
 // Use the native word size as the group size. Using a 64-bit group size on
 // a 32-bit architecture will just end up being more expensive because

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,13 +1,12 @@
+use core::iter::FusedIterator;
+use core::marker::PhantomData;
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::ptr::NonNull;
+use core::{hint, mem, ptr};
+
 use crate::alloc::alloc::{handle_alloc_error, Layout};
 use crate::scopeguard::{guard, ScopeGuard};
 use crate::TryReserveError;
-use core::iter::FusedIterator;
-use core::marker::PhantomData;
-use core::mem;
-use core::mem::ManuallyDrop;
-use core::mem::MaybeUninit;
-use core::ptr::NonNull;
-use core::{hint, ptr};
 
 cfg_if! {
     // Use the SSE2 implementation if possible: it allows us to scan 16 buckets
@@ -37,13 +36,13 @@ pub(crate) use self::alloc::{do_alloc, Allocator, Global};
 
 mod bitmask;
 
-use self::bitmask::{BitMask, BitMaskIter};
-use self::imp::Group;
-
 // Branch prediction hint. This is currently only available on nightly but it
 // consistently improves performance by 10-15%.
 #[cfg(feature = "nightly")]
 use core::intrinsics::{likely, unlikely};
+
+use self::bitmask::{BitMask, BitMaskIter};
+use self::imp::Group;
 
 // On stable we can use #[cold] to get a equivalent effect: this attributes
 // suggests that the function is unlikely to be called

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -1,11 +1,11 @@
-use super::bitmask::BitMask;
-use super::EMPTY;
-use core::mem;
-
 #[cfg(target_arch = "x86")]
 use core::arch::x86;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64 as x86;
+use core::mem;
+
+use super::bitmask::BitMask;
+use super::EMPTY;
 
 pub type BitMaskWord = u16;
 pub const BITMASK_STRIDE: usize = 1;

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -1,9 +1,10 @@
-use self::RustcEntry::*;
-use crate::map::{make_insert_hash, Drain, HashMap, IntoIter, Iter, IterMut};
-use crate::raw::{Allocator, Bucket, Global, RawTable};
 use core::fmt::{self, Debug};
 use core::hash::{BuildHasher, Hash};
 use core::mem;
+
+use self::RustcEntry::*;
+use crate::map::{make_insert_hash, Drain, HashMap, IntoIter, Iter, IterMut};
+use crate::raw::{Allocator, Bucket, Global, RawTable};
 
 impl<K, V, S, A> HashMap<K, V, S, A>
 where

--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -1,9 +1,7 @@
 // Extracted from the scopeguard crate
-use core::{
-    mem::ManuallyDrop,
-    ops::{Deref, DerefMut},
-    ptr,
-};
+use core::mem::ManuallyDrop;
+use core::ops::{Deref, DerefMut};
+use core::ptr;
 
 pub struct ScopeGuard<T, F>
 where

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,15 +1,14 @@
-#[cfg(feature = "raw")]
-use crate::raw::RawTable;
-use crate::{Equivalent, TryReserveError};
 use alloc::borrow::ToOwned;
-use core::fmt;
 use core::hash::{BuildHasher, Hash};
 use core::iter::{Chain, FromIterator, FusedIterator};
-use core::mem;
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
+use core::{fmt, mem};
 
 use super::map::{self, ConsumeAllOnDrop, DefaultHashBuilder, DrainFilterInner, HashMap, Keys};
+#[cfg(feature = "raw")]
+use crate::raw::RawTable;
 use crate::raw::{Allocator, Global};
+use crate::{Equivalent, TryReserveError};
 
 // Future Optimization (FIXME!)
 // =============================
@@ -2428,9 +2427,10 @@ fn assert_covariance() {
 
 #[cfg(test)]
 mod test_set {
+    use std::vec::Vec;
+
     use super::super::map::DefaultHashBuilder;
     use super::HashSet;
-    use std::vec::Vec;
 
     #[test]
     fn test_zero_capacities() {

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -1,7 +1,6 @@
-use hashbrown::Equivalent;
-use hashbrown::HashMap;
-
 use std::hash::Hash;
+
+use hashbrown::{Equivalent, HashMap};
 
 #[derive(Debug, Hash)]
 pub struct Pair<A, B>(pub A, pub B);

--- a/tests/hasher.rs
+++ b/tests/hasher.rs
@@ -2,8 +2,9 @@
 
 #![cfg(not(miri))] // FIXME: takes too long
 
-use hashbrown::HashSet;
 use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
+
+use hashbrown::HashSet;
 
 fn check<S: BuildHasher + Default>() {
     let range = 0..1_000;

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "serde")]
 
 use core::hash::BuildHasherDefault;
+
 use fnv::FnvHasher;
 use hashbrown::{HashMap, HashSet};
 use serde_test::{assert_tokens, Token};

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -1,8 +1,11 @@
 #![cfg(not(miri))] // FIXME: takes too long
 
-use hashbrown::HashSet;
-use rand::{distributions::Alphanumeric, rngs::SmallRng, Rng, SeedableRng};
 use std::iter;
+
+use hashbrown::HashSet;
+use rand::distributions::Alphanumeric;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
 
 #[test]
 fn test_hashset_insert_remove() {


### PR DESCRIPTION
```
group_imports = "StdExternalCrate"
imports_granularity = "Module"
```

`imports_granularity = "Item"` seems to be the best for merge conflicts, grepping etc, but seems like most of code in this project formatted with either `"Module"` or `"Crate"`, so I put `"Module"` there.

`group_imports` groups dependencies which is convenient.

Any code style is better than no style, so I can replace config with other values.

Feel free to reject the PR.