### PR TITLE
Provide default hasher types to `Vacant` and `Occupied` entries

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -4297,7 +4297,7 @@ impl<K: Debug, V: Debug, S, A: Allocator + Clone> Debug for Entry<'_, K, V, S, A
 /// assert_eq!(map.get(&"c"), None);
 /// assert_eq!(map.len(), 2);
 /// ```
-pub struct OccupiedEntry<'a, K, V, S, A: Allocator + Clone = Global> {
+pub struct OccupiedEntry<'a, K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
     hash: u64,
     key: Option<K>,
     elem: Bucket<(K, V)>,
@@ -4360,7 +4360,7 @@ impl<K: Debug, V: Debug, S, A: Allocator + Clone> Debug for OccupiedEntry<'_, K,
 /// }
 /// assert!(map[&"b"] == 20 && map.len() == 2);
 /// ```
-pub struct VacantEntry<'a, K, V, S, A: Allocator + Clone = Global> {
+pub struct VacantEntry<'a, K, V, S = DefaultHashBuilder, A: Allocator + Clone = Global> {
     hash: u64,
     key: K,
     table: &'a mut HashMap<K, V, S, A>,


### PR DESCRIPTION
For code which may select to use the `std` `HashMap` or the `hashbrown` `HashMap` based on feature or cfg flags, being forced to provide an explicit hash argument to `VacantEntry` or `OccupiedEntry` structs requires jumping through some hoops. Specifically, the `std` `hash_map::*Entry` structs don't take a hasher type argument at all, making the downstream code change the type entirely when switching from `std` to `hashbrown` or back.

For simplicity, its nice to have the argument be optional on the `hashbrown` end, which would let the same code compile with either map.