### PR TITLE
Experiment with Equivalent that takes self by value

### DIFF
--- a/src/external_trait_impls/rayon/map.rs
+++ b/src/external_trait_impls/rayon/map.rs
@@ -561,10 +561,7 @@ mod test_par_map {
             assert_eq!(value.load(Ordering::Relaxed), 100);
 
             // retain only half
-            let _v: Vec<_> = hm
-                .into_par_iter()
-                .filter(|&(ref key, _)| key.k < 50)
-                .collect();
+            let _v: Vec<_> = hm.into_par_iter().filter(|(key, _)| key.k < 50).collect();
 
             assert_eq!(key.load(Ordering::Relaxed), 50);
             assert_eq!(value.load(Ordering::Relaxed), 50);
@@ -611,7 +608,7 @@ mod test_par_map {
             assert_eq!(value.load(Ordering::Relaxed), 100);
 
             // retain only half
-            let _v: Vec<_> = hm.drain().filter(|&(ref key, _)| key.k < 50).collect();
+            let _v: Vec<_> = hm.drain().filter(|(key, _)| key.k < 50).collect();
             assert!(hm.is_empty());
 
             assert_eq!(key.load(Ordering::Relaxed), 50);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub use crate::set::HashSet;
 /// # Correctness
 ///
 /// Equivalent values must hash to the same value.
-pub trait Equivalent<K: ?Sized> {
+pub trait Equivalent<K: ?Sized>: Copy {
     /// Checks if this value is equivalent to the given key.
     ///
     /// Returns `true` if both values are equivalent, and `false` otherwise.
@@ -137,16 +137,16 @@ pub trait Equivalent<K: ?Sized> {
     ///
     /// When this function returns `true`, both `self` and `key` must hash to
     /// the same value.
-    fn equivalent(&self, key: &K) -> bool;
+    fn equivalent(self, key: &K) -> bool;
 }
 
-impl<Q: ?Sized, K: ?Sized> Equivalent<K> for Q
+impl<Q: ?Sized, K: ?Sized> Equivalent<K> for &Q
 where
     Q: Eq,
     K: core::borrow::Borrow<Q>,
 {
-    fn equivalent(&self, key: &K) -> bool {
-        self == key.borrow()
+    fn equivalent(self, key: &K) -> bool {
+        Q::eq(self, key.borrow())
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -856,7 +856,7 @@ where
     /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
+    pub fn contains<Q>(&self, value: Q) -> bool
     where
         Q: Hash + Equivalent<T>,
     {
@@ -882,7 +882,7 @@ where
     /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
+    pub fn get<Q>(&self, value: Q) -> Option<&T>
     where
         Q: Hash + Equivalent<T>,
     {
@@ -937,9 +937,10 @@ where
     /// assert_eq!(set.len(), 4); // a new "fish" was inserted
     /// ```
     #[inline]
-    pub fn get_or_insert_owned<Q: ?Sized>(&mut self, value: &Q) -> &T
+    pub fn get_or_insert_owned<'q, Q: ?Sized>(&mut self, value: &'q Q) -> &T
     where
-        Q: Hash + Equivalent<T> + ToOwned<Owned = T>,
+        &'q Q: Hash + Equivalent<T>,
+        Q: ToOwned<Owned = T>,
     {
         // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
         // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
@@ -969,10 +970,10 @@ where
     /// assert_eq!(set.len(), 4); // a new "fish" was inserted
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
+    pub fn get_or_insert_with<Q, F>(&mut self, value: Q, f: F) -> &T
     where
         Q: Hash + Equivalent<T>,
-        F: FnOnce(&Q) -> T,
+        F: FnOnce(Q) -> T,
     {
         // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
         // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
@@ -1185,7 +1186,7 @@ where
     /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+    pub fn remove<Q>(&mut self, value: Q) -> bool
     where
         Q: Hash + Equivalent<T>,
     {
@@ -1211,7 +1212,7 @@ where
     /// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
     /// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+    pub fn take<Q>(&mut self, value: Q) -> Option<T>
     where
         Q: Hash + Equivalent<T>,
     {

--- a/src/set.rs
+++ b/src/set.rs
@@ -2713,10 +2713,10 @@ mod test_set {
         set.insert(1);
         set.insert(2);
 
-        let set_str = format!("{:?}", set);
+        let set_str = format!("{set:?}");
 
         assert!(set_str == "{1, 2}" || set_str == "{2, 1}");
-        assert_eq!(format!("{:?}", empty), "{}");
+        assert_eq!(format!("{empty:?}"), "{}");
     }
 
     #[test]

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -27,7 +27,7 @@ fn test_hashset_insert_remove() {
             assert_eq!(m.insert(x.clone()), true);
         }
         for (i, x) in tx.iter().enumerate() {
-            println!("removing {} {:?}", i, x);
+            println!("removing {i} {x:?}");
             assert_eq!(m.remove(x), true);
         }
     }


### PR DESCRIPTION
We're talking about sharing the `Equivalent` trait with `indexmap`, and I'm trying changes:
https://github.com/bluss/indexmap/issues/253#issuecomment-1418304168

While this changes a lot of API signatures, note that I didn't have to change any test code, except the one implementing `Equivalent` manually of course.