### PR TITLE
Add `HashSet::get_or_insert_with_mut`

### DIFF
--- a/src/set.rs
+++ b/src/set.rs
@@ -951,7 +951,8 @@ where
     }
 
     /// Inserts a value computed from `f` into the set if the given `value` is
-    /// not present, then returns a reference to the value in the set.
+    /// not present, then returns a reference to the value in the set. The value
+    /// computed by `f` should have the same hash and compare equivalent to `value`.
     ///
     /// # Examples
     ///
@@ -984,7 +985,8 @@ where
     }
 
     /// Inserts a value computed from `f` into the set if the given `value` is
-    /// not present, then returns a reference to the value in the set.
+    /// not present, then returns a reference to the value in the set. The value
+    /// computed by `f` should have the same hash and compare equivalent to `value`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This function avoids unnecessairy work when the value to be stored can take ownership of the lookup key, such as when interning. It makes a stronger guarantee than `HashSet::get_or_insert_with`, since the reference given to `f` is guaranteed to be unique, and thus safe to mutate.

The functionality of this function can already be achieved by (ab)using `UnsafeCell`, but that relies on the implementation detail that the `&Q` given to `f` is unique.