### PR TITLE
raw_table + raw_table_mut

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2123,6 +2123,18 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
         RawEntryBuilder { map: self }
     }
 
+    /// Returns a reference to the [`RawTable`] used underneath [`HashMap`].
+    /// This function is only available if the `raw` feature of the crate is enabled.
+    /// 
+    /// See [`raw_table_mut`] for more.
+    /// 
+    /// [`raw_table_mut`]: Self::raw_table_mut
+    #[cfg(feature = "raw")]
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn raw_table(&self) -> &RawTable<(K, V), A> {
+        &self.table
+    }    
+
     /// Returns a mutable reference to the [`RawTable`] used underneath [`HashMap`].
     /// This function is only available if the `raw` feature of the crate is enabled.
     ///
@@ -2159,7 +2171,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// where
     ///     F: Fn(&(K, V)) -> bool,
     /// {
-    ///     let raw_table = map.raw_table();
+    ///     let raw_table = map.raw_table_mut();
     ///     match raw_table.find(hash, is_match) {
     ///         Some(bucket) => Some(unsafe { raw_table.remove(bucket) }),
     ///         None => None,
@@ -2180,7 +2192,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// ```
     #[cfg(feature = "raw")]
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn raw_table(&mut self) -> &mut RawTable<(K, V), A> {
+    pub fn raw_table_mut(&mut self) -> &mut RawTable<(K, V), A> {
         &mut self.table
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -2125,15 +2125,15 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
 
     /// Returns a reference to the [`RawTable`] used underneath [`HashMap`].
     /// This function is only available if the `raw` feature of the crate is enabled.
-    /// 
+    ///
     /// See [`raw_table_mut`] for more.
-    /// 
+    ///
     /// [`raw_table_mut`]: Self::raw_table_mut
     #[cfg(feature = "raw")]
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_table(&self) -> &RawTable<(K, V), A> {
         &self.table
-    }    
+    }
 
     /// Returns a mutable reference to the [`RawTable`] used underneath [`HashMap`].
     /// This function is only available if the `raw` feature of the crate is enabled.

--- a/src/set.rs
+++ b/src/set.rs
@@ -1222,6 +1222,26 @@ where
         }
     }
 
+    /// Returns a reference to the [`RawTable`] used underneath [`HashSet`].
+    /// This function is only available if the `raw` feature of the crate is enabled.
+    ///
+    /// # Note
+    ///
+    /// Calling this function is safe, but using the raw hash table API may require
+    /// unsafe functions or blocks.
+    ///
+    /// `RawTable` API gives the lowest level of control under the set that can be useful
+    /// for extending the HashSet's API, but may lead to *[undefined behavior]*.
+    ///
+    /// [`HashSet`]: struct.HashSet.html
+    /// [`RawTable`]: crate::raw::RawTable
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
+    #[cfg(feature = "raw")]
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn raw_table(&self) -> &RawTable<(T, ()), A> {
+        self.map.raw_table()
+    }    
+
     /// Returns a mutable reference to the [`RawTable`] used underneath [`HashSet`].
     /// This function is only available if the `raw` feature of the crate is enabled.
     ///
@@ -1238,8 +1258,8 @@ where
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[cfg(feature = "raw")]
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn raw_table(&mut self) -> &mut RawTable<(T, ()), A> {
-        self.map.raw_table()
+    pub fn raw_table_mut(&mut self) -> &mut RawTable<(T, ()), A> {
+        self.map.raw_table_mut()
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1240,7 +1240,7 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_table(&self) -> &RawTable<(T, ()), A> {
         self.map.raw_table()
-    }    
+    }
 
     /// Returns a mutable reference to the [`RawTable`] used underneath [`HashSet`].
     /// This function is only available if the `raw` feature of the crate is enabled.


### PR DESCRIPTION
Immutable access to `RawTable` from both `HashMap` and `HashSet`.

Implements https://github.com/rust-lang/hashbrown/issues/403