### PR TITLE
Implement iterator which starts at arbitrary location

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -824,7 +824,7 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
     /// assert_eq!(map.len(), 3);
     /// let mut vec: Vec<(&str, i32)> = Vec::new();
     ///
-    /// for (key, val) in map.iter_at(0x517cc1b727220a95_usize) {
+    /// for (key, val) in map.iter_at(0x517cc1b727220a95u64 as usize) {
     ///     println!("key: {} val: {}", key, val);
     ///     vec.push((*key, *val));
     /// }
@@ -4889,7 +4889,7 @@ impl<K, V> FusedIterator for Iter<'_, K, V> {}
 ///
 /// let map: HashMap<_, _> = [(1, "a"), (2, "b"), (3, "c")].into();
 ///
-/// let mut iter = map.iter_at(0x517cc1b727220a95_usize);
+/// let mut iter = map.iter_at(0x517cc1b727220a95u64 as usize);
 /// let mut vec = vec![iter.next(), iter.next(), iter.next()];
 ///
 /// // The `IterHinted` iterator produces items in arbitrary order, so the
@@ -8719,7 +8719,9 @@ mod test_map {
             #[cfg(not(miri))]
             const K: usize = 16;
             for k in 0..K {
-                let hint = 0x517cc1b727220a95_usize.wrapping_mul(i).wrapping_add(k);
+                let hint = (0x517cc1b727220a95u64 as usize)
+                    .wrapping_mul(i)
+                    .wrapping_add(k);
                 for (k, _) in h.iter_at(hint) {
                     s[*k] += 1;
                 }


### PR DESCRIPTION
This PR implements iterator which starts at arbitrary location in the table. There are several motivations for this change:

- For security reasons one may wish to start iterations at arbitrary locations in the table. That what golang is doing
- For implementing efficient pseudo-random sampling from the table (e.g for use in probabilistic algorithms)
- For being able to port golang code with 100% semantic preservation

See this [issue](https://github.com/al8n/stretto/issues/37) for a real-world motivating example.

That is just POC, if the idea in principle is acceptable I would be happy to shape it with some guidance from maintainers.