### PR TITLE
Relax the trait bounds of `HashSet::raw_table{,_mut}`

### DIFF
--- a/src/set.rs
+++ b/src/set.rs
@@ -1221,7 +1221,9 @@ where
             None => None,
         }
     }
+}
 
+impl<T, S, A: Allocator + Clone> HashSet<T, S, A> {
     /// Returns a reference to the [`RawTable`] used underneath [`HashSet`].
     /// This function is only available if the `raw` feature of the crate is enabled.
     ///


### PR DESCRIPTION
Removes the trait bounds `T: Eq + Hash, S: BuildHasher` from `HashSet<T, S, A>::raw_table{,_mut}`.

Considering that the `HashMap` counterpart doesn't have these bounds, they are likely unintentional.