### PR TITLE
Change key to return `&K` rather than `&Q`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -5928,8 +5928,7 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> EntryRef<'a, 'b, K, Q, V,
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn and_replace_entry_with<F>(self, f: F) -> Self
     where
-        F: FnOnce(&Q, V) -> Option<V>,
-        K: Borrow<Q>,
+        F: FnOnce(&K, V) -> Option<V>,
     {
         match self {
             EntryRef::Occupied(entry) => entry.replace_entry_with(f),
@@ -6294,8 +6293,7 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> OccupiedEntryRef<'a, 'b, 
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace_entry_with<F>(self, f: F) -> EntryRef<'a, 'b, K, Q, V, S, A>
     where
-        F: FnOnce(&Q, V) -> Option<V>,
-        K: Borrow<Q>,
+        F: FnOnce(&K, V) -> Option<V>,
     {
         unsafe {
             let mut spare_key = None;
@@ -6303,7 +6301,7 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> OccupiedEntryRef<'a, 'b, 
             self.table
                 .table
                 .replace_bucket_with(self.elem.clone(), |(key, value)| {
-                    if let Some(new_value) = f(key.borrow(), value) {
+                    if let Some(new_value) = f(&key, value) {
                         Some((key, new_value))
                     } else {
                         spare_key = Some(KeyOrRef::Owned(key));

--- a/src/map.rs
+++ b/src/map.rs
@@ -4562,7 +4562,7 @@ impl<K: Borrow<Q>, Q: ?Sized + Debug, V: Debug, S, A: Allocator + Clone> Debug
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OccupiedEntryRef")
-            .field("key", &self.key())
+            .field("key", &self.key().borrow())
             .field("value", &self.get())
             .finish()
     }
@@ -5832,7 +5832,7 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> EntryRef<'a, 'b, K, Q, V,
         K: Borrow<Q>,
     {
         match *self {
-            EntryRef::Occupied(ref entry) => entry.key(),
+            EntryRef::Occupied(ref entry) => entry.key().borrow(),
             EntryRef::Vacant(ref entry) => entry.key(),
         }
     }
@@ -5988,11 +5988,8 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator + Clone> OccupiedEntryRef<'a, 'b, 
     /// }
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn key(&self) -> &Q
-    where
-        K: Borrow<Q>,
-    {
-        unsafe { &self.elem.as_ref().0 }.borrow()
+    pub fn key(&self) -> &K {
+        unsafe { &self.elem.as_ref().0 }
     }
 
     /// Take the ownership of the key and value from the map.


### PR DESCRIPTION
also changes `EntryRef::and_replace_entry_with` and `OccupiedEntryRef::replace_entry_with` to also give out `&K`

Fixes: #421