### PR TITLE
Special case `clear()` on empty tables

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1027,6 +1027,10 @@ impl<T, A: Allocator + Clone> RawTable<T, A> {
     /// Removes all elements from the table without freeing the backing memory.
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn clear(&mut self) {
+        if self.is_empty() {
+            // Special case empty table to avoid surprising O(capacity) time.
+            return;
+        }
         // Ensure that the table is reset even if one of the drops panic
         let mut self_ = guard(self, |self_| self_.clear_no_drop());
         unsafe {


### PR DESCRIPTION
Special case `clear()` to avoid `O(capacity)` runtime even on an empty set.

There are workloads which currently needs `if !map.is_empty() { map.clear(); }` for optimal performance, which looks odd (and that it's necessary may be surprising).

Special casing empty table aligns with what [java.util.HashMap](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/HashMap.java#L867) is doing.

After discussion with @forny.