### PR TITLE
Clean up `RawTable` API

### DIFF
--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -330,7 +330,7 @@ impl<'a, K, V, A: Allocator + Clone> RustcOccupiedEntry<'a, K, V, A> {
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove_entry(self) -> (K, V) {
-        unsafe { self.table.remove(self.elem) }
+        unsafe { self.table.remove(self.elem).0 }
     }
 
     /// Gets a reference to the value in the entry.


### PR DESCRIPTION
This cleans up various issues in the `RawTable` API:
- `RawIter::{reflect_insert, reflect_remove}` are now unsafe.
- `RawTable::find_potential` is renamed to `find_or_find_insert_slot` and returns an `InsertSlot`.
- `RawTable::remove` now also returns an `InsertSlot`.
- `InsertSlot` can be used to insert an element with `RawTable::insert_in_slot`.

Fixes #412