### PR TITLE
Add NEON backend for RawTable

### DIFF
--- a/src/raw/generic.rs
+++ b/src/raw/generic.rs
@@ -25,6 +25,7 @@ pub(crate) const BITMASK_STRIDE: usize = 8;
 // We only care about the highest bit of each byte for the mask.
 #[allow(clippy::cast_possible_truncation, clippy::unnecessary_cast)]
 pub(crate) const BITMASK_MASK: BitMaskWord = 0x8080_8080_8080_8080_u64 as GroupWord;
+pub(crate) const BITMASK_ITER_MASK: BitMaskWord = !0;
 
 /// Helper function to replicate a byte across a `GroupWord`.
 #[inline]

--- a/src/raw/neon.rs
+++ b/src/raw/neon.rs
@@ -1,25 +1,20 @@
 use super::bitmask::BitMask;
 use super::EMPTY;
+use core::arch::aarch64 as neon;
 use core::mem;
 
-#[cfg(target_arch = "x86")]
-use core::arch::x86;
-#[cfg(target_arch = "x86_64")]
-use core::arch::x86_64 as x86;
-
-pub(crate) type BitMaskWord = u16;
-pub(crate) const BITMASK_STRIDE: usize = 1;
-pub(crate) const BITMASK_MASK: BitMaskWord = 0xffff;
-pub(crate) const BITMASK_ITER_MASK: BitMaskWord = !0;
+pub(crate) type BitMaskWord = u64;
+pub(crate) const BITMASK_STRIDE: usize = 8;
+pub(crate) const BITMASK_MASK: BitMaskWord = !0;
+pub(crate) const BITMASK_ITER_MASK: BitMaskWord = 0x8080_8080_8080_8080;
 
 /// Abstraction over a group of control bytes which can be scanned in
 /// parallel.
 ///
-/// This implementation uses a 128-bit SSE value.
+/// This implementation uses a 64-bit NEON value.
 #[derive(Copy, Clone)]
-pub(crate) struct Group(x86::__m128i);
+pub(crate) struct Group(neon::uint8x8_t);
 
-// FIXME: https://github.com/rust-lang/rust-clippy/issues/3859
 #[allow(clippy::use_self)]
 impl Group {
     /// Number of bytes in the group.
@@ -30,7 +25,6 @@ impl Group {
     ///
     /// This is guaranteed to be aligned to the group size.
     #[inline]
-    #[allow(clippy::items_after_statements)]
     pub(crate) const fn static_empty() -> &'static [u8; Group::WIDTH] {
         #[repr(C)]
         struct AlignedBytes {
@@ -48,7 +42,7 @@ impl Group {
     #[inline]
     #[allow(clippy::cast_ptr_alignment)] // unaligned load
     pub(crate) unsafe fn load(ptr: *const u8) -> Self {
-        Group(x86::_mm_loadu_si128(ptr.cast()))
+        Group(neon::vld1_u8(ptr))
     }
 
     /// Loads a group of bytes starting at the given address, which must be
@@ -58,7 +52,7 @@ impl Group {
     pub(crate) unsafe fn load_aligned(ptr: *const u8) -> Self {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        Group(x86::_mm_load_si128(ptr.cast()))
+        Group(neon::vld1_u8(ptr))
     }
 
     /// Stores the group of bytes to the given address, which must be
@@ -68,24 +62,16 @@ impl Group {
     pub(crate) unsafe fn store_aligned(self, ptr: *mut u8) {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        x86::_mm_store_si128(ptr.cast(), self.0);
+        neon::vst1_u8(ptr, self.0);
     }
 
-    /// Returns a `BitMask` indicating all bytes in the group which have
-    /// the given value.
+    /// Returns a `BitMask` indicating all bytes in the group which *may*
+    /// have the given value.
     #[inline]
     pub(crate) fn match_byte(self, byte: u8) -> BitMask {
-        #[allow(
-            clippy::cast_possible_wrap, // byte: u8 as i8
-            // byte: i32 as u16
-            //   note: _mm_movemask_epi8 returns a 16-bit mask in a i32, the
-            //   upper 16-bits of the i32 are zeroed:
-            clippy::cast_sign_loss,
-            clippy::cast_possible_truncation
-        )]
         unsafe {
-            let cmp = x86::_mm_cmpeq_epi8(self.0, x86::_mm_set1_epi8(byte as i8));
-            BitMask(x86::_mm_movemask_epi8(cmp) as u16)
+            let cmp = neon::vceq_u8(self.0, neon::vdup_n_u8(byte));
+            BitMask(neon::vget_lane_u64(neon::vreinterpret_u64_u8(cmp), 0))
         }
     }
 
@@ -100,23 +86,19 @@ impl Group {
     /// `EMPTY` or `DELETED`.
     #[inline]
     pub(crate) fn match_empty_or_deleted(self) -> BitMask {
-        #[allow(
-            // byte: i32 as u16
-            //   note: _mm_movemask_epi8 returns a 16-bit mask in a i32, the
-            //   upper 16-bits of the i32 are zeroed:
-            clippy::cast_sign_loss,
-            clippy::cast_possible_truncation
-        )]
         unsafe {
-            // A byte is EMPTY or DELETED iff the high bit is set
-            BitMask(x86::_mm_movemask_epi8(self.0) as u16)
+            let cmp = neon::vcltz_s8(neon::vreinterpret_s8_u8(self.0));
+            BitMask(neon::vget_lane_u64(neon::vreinterpret_u64_u8(cmp), 0))
         }
     }
 
     /// Returns a `BitMask` indicating all bytes in the group which are full.
     #[inline]
-    pub(crate) fn match_full(&self) -> BitMask {
-        self.match_empty_or_deleted().invert()
+    pub(crate) fn match_full(self) -> BitMask {
+        unsafe {
+            let cmp = neon::vcgez_s8(neon::vreinterpret_s8_u8(self.0));
+            BitMask(neon::vget_lane_u64(neon::vreinterpret_u64_u8(cmp), 0))
+        }
     }
 
     /// Performs the following transformation on all bytes in the group:
@@ -132,16 +114,9 @@ impl Group {
         //   let special = 0 > byte = 1111_1111 (true) or 0000_0000 (false)
         //   1111_1111 | 1000_0000 = 1111_1111
         //   0000_0000 | 1000_0000 = 1000_0000
-        #[allow(
-            clippy::cast_possible_wrap, // byte: 0x80_u8 as i8
-        )]
         unsafe {
-            let zero = x86::_mm_setzero_si128();
-            let special = x86::_mm_cmpgt_epi8(zero, self.0);
-            Group(x86::_mm_or_si128(
-                special,
-                x86::_mm_set1_epi8(0x80_u8 as i8),
-            ))
+            let special = neon::vcltz_s8(neon::vreinterpret_s8_u8(self.0));
+            Group(neon::vorr_u8(special, neon::vdup_n_u8(0x80)))
         }
     }
 }


### PR DESCRIPTION
The core algorithm is based on the NEON support in [SwissTable], adapted for the different control byte encodings used in hashbrown.

[SwissTable]: https://github.com/abseil/abseil-cpp/commit/6481443560a92d0a3a55a31807de0cd712cd4f88