### PR TITLE
Bump MSRV to 1.64

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           thumbv6m-none-eabi,
           x86_64-pc-windows-gnu,
         ]
-        channel: [1.63.0, nightly]
+        channel: [1.64.0, nightly]
         include:
         - os: macos-latest
           target: x86_64-apple-darwin
@@ -60,13 +60,13 @@ jobs:
           channel: nightly
         - os: macos-latest
           target: x86_64-apple-darwin
-          channel: 1.63.0
+          channel: 1.64.0
         - os: windows-latest
           target: x86_64-pc-windows-msvc
-          channel: 1.63.0
+          channel: 1.64.0
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          channel: 1.63.0
+          channel: 1.64.0
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           channel: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["hash", "no_std", "hashmap", "swisstable"]
 categories = ["data-structures", "no-std"]
 exclude = [".github", "/ci/*"]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 
 [dependencies]
 # For the default hasher

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hashbrown
 [![Build Status](https://github.com/rust-lang/hashbrown/actions/workflows/rust.yml/badge.svg)](https://github.com/rust-lang/hashbrown/actions)
 [![Crates.io](https://img.shields.io/crates/v/hashbrown.svg)](https://crates.io/crates/hashbrown)
 [![Documentation](https://docs.rs/hashbrown/badge.svg)](https://docs.rs/hashbrown)
-[![Rust](https://img.shields.io/badge/rust-1.63.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
+[![Rust](https://img.shields.io/badge/rust-1.64.0%2B-blue.svg?maxAge=3600)](https://github.com/rust-lang/hashbrown)
 
 This crate is a Rust port of Google's high-performance [SwissTable] hash
 map, adapted to make it a drop-in replacement for Rust's standard `HashMap`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
         allocator_api,
         slice_ptr_get,
         maybe_uninit_array_assume_init,
-        build_hasher_simple_hash_one,
         strict_provenance
     )
 )]


### PR DESCRIPTION
This is due to the MSRV of the `allocator-api2` dependency.