### PR TITLE
Avoid reporting a capacity of zero when there is still space in the map.

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -619,6 +619,15 @@ impl<K, V, S, A: Allocator + Clone> HashMap<K, V, S, A> {
         self.table.capacity()
     }
 
+    /// Returns the maximum number of elements the map could potentially hold
+    /// without reallocating.
+    ///
+    /// This number is an upper bound.
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn max_capacity(&self) -> usize {
+        self.table.max_capacity()
+    }
+
     /// An iterator visiting all keys in arbitrary order.
     /// The iterator element type is `&'a K`.
     ///


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/79178

There are two changes in this PR:

1) Add a `max_capacity()` method. The `capacity()` method provides a lower bound on the capacity, this complements it by providing an upper bound. There are some use-cases (such as deciding when to call `shrink_to_fit()`) when using the upper bound on the capacity may be more appropriate.

2) Recover "lost" capacity when the map is fully emptied if there are a large number of tombstones. Currently this happens when the reported capacity would be less than or equal to half the actual capacity of the map. The most important case is when the reported capacity would be zero, but we haven't deallocated the backing memory: with this change a positive capacity will be reported.