### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ rust-version = "1.64.0"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.8.0", default-features = false, optional = true }
+ahash = { version = "0.8.3", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }
-serde = { version = "1.0.25", default-features = false, optional = true }
+serde = { version = "1.0.164", default-features = false, optional = true }
 rkyv = { version = "0.7.42", optional = true, default-features = false, features = ["alloc"]}
 
 # When built as part of libstd
@@ -31,11 +31,11 @@ allocator-api2 = { version = "0.2.9", optional = true, default-features = false,
 
 [dev-dependencies]
 lazy_static = "1.4"
-rand = { version = "0.8.3", features = ["small_rng"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
 rayon = "1.0"
 fnv = "1.0.7"
 serde_test = "1.0"
-doc-comment = "0.3.1"
+doc-comment = "0.3.3"
 bumpalo = { version = "3.13.0", features = ["allocator-api2"] }
 rkyv = { version = "0.7.42", features = ["validation"] }
 


### PR DESCRIPTION
Patches include bug fixes and improvements.

Result `cargo test`:
```
test result: ok. 221 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 101.92s
```

Some improvements are even significant.

[Update `aHash 0.8.1 [Nov 1, 2022]`](https://github.com/tkaitchuck/aHash/compare/v0.8.0...v0.8.1):
```
- Fix compiler error on wasm with default features.
- Significant improvements to speed on unusual architectures (Things other than: x86_64, aarch64, mips64, powerpc64, riscv64gc, or s390x)
...
- Fix AVR support by using atomic-polyfill
- Simplify the way that flags work
```