### PR TITLE
Use the `Equivalent` trait from the `equivalent` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ ahash = { version = "0.8.0", default-features = false, optional = true }
 # For external trait impls
 rayon = { version = "1.0", optional = true }
 serde = { version = "1.0.25", default-features = false, optional = true }
-rkyv = { version = "0.7.42", optional = true, default-features = false, features = ["alloc"]}
+rkyv = { version = "0.7.42", optional = true, default-features = false, features = [
+    "alloc",
+] }
 
 # When built as part of libstd
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
@@ -27,7 +29,12 @@ compiler_builtins = { version = "0.1.2", optional = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
 # Support for allocators that use allocator-api2
-allocator-api2 = { version = "0.2.9", optional = true, default-features = false, features = ["alloc"] }
+allocator-api2 = { version = "0.2.9", optional = true, default-features = false, features = [
+    "alloc",
+] }
+
+# Equivalent trait which can be shared with other hash table implementations.
+equivalent = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
 lazy_static = "1.4"
@@ -45,7 +52,13 @@ default = ["ahash", "inline-more", "allocator-api2"]
 nightly = ["allocator-api2?/nightly", "bumpalo/allocator_api"]
 
 rustc-internal-api = []
-rustc-dep-of-std = ["nightly", "core", "compiler_builtins", "alloc", "rustc-internal-api"]
+rustc-dep-of-std = [
+    "nightly",
+    "core",
+    "compiler_builtins",
+    "alloc",
+    "rustc-internal-api",
+]
 raw = []
 
 # Enables usage of `#[inline]` on far more functions than by default in this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,11 @@ pub mod hash_set {
 pub use crate::map::HashMap;
 pub use crate::set::HashSet;
 
+#[cfg(feature = "equivalent")]
+use equivalent::Equivalent;
+
+// This is only used as a fallback when building as part of `std`.
+#[cfg(not(feature = "equivalent"))]
 /// Key equivalence trait.
 ///
 /// This trait defines the function used to compare the input value with the
@@ -140,6 +145,7 @@ pub trait Equivalent<K: ?Sized> {
     fn equivalent(&self, key: &K) -> bool;
 }
 
+#[cfg(not(feature = "equivalent"))]
 impl<Q: ?Sized, K: ?Sized> Equivalent<K> for Q
 where
     Q: Eq,


### PR DESCRIPTION
This allows types implementating the `Equivalent` trait to work with other hash table, such as `IndexMap`.

See https://github.com/bluss/indexmap/issues/253.