### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ inline-more = []
 
 [package.metadata.docs.rs]
 features = ["nightly", "rayon", "serde", "raw"]
+rustdoc-args = ["--generate-link-to-definition"]


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).