### PR TITLE
Temporary fix `cross` and `CI`

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,17 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main"
+
+[target.i686-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/i686-unknown-linux-gnu:main"
+
+[target.i586-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/i586-unknown-linux-gnu:main"
+
+[target.armv7-unknown-linux-gnueabihf]
+image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:main"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+
+[target.thumbv6m-none-eabi]
+image = "ghcr.io/cross-rs/thumbv6m-none-eabi:main"


### PR DESCRIPTION
Didn't find a better way. Can delete this file after a new version of `cross` is released