### PR TITLE
Shared context

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -3242,7 +3242,11 @@ impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilderMut<'a, K, V, S, A> {
     where
         for<'b> F: FnMut(&'b K) -> bool,
     {
-        match self.map.table.find(hash, |(k, _)| is_match(k)) {
+        match self
+            .map
+            .table
+            .find_with_context(&mut is_match, hash, |is_match, (k, _)| is_match(k))
+        {
             Some(elem) => RawEntryMut::Occupied(RawOccupiedEntryMut {
                 elem,
                 table: &mut self.map.table,
@@ -3313,7 +3317,11 @@ impl<'a, K, V, S, A: Allocator + Clone> RawEntryBuilder<'a, K, V, S, A> {
     where
         F: FnMut(&K) -> bool,
     {
-        match self.map.table.get(hash, |(k, _)| is_match(k)) {
+        match self
+            .map
+            .table
+            .get_with_context(&mut is_match, hash, |is_match, (k, _)| is_match(k))
+        {
             Some((key, value)) => Some((key, value)),
             None => None,
         }


### PR DESCRIPTION
Supersedes #459

Based on [this comment](https://github.com/rust-lang/hashbrown/issues/456#issuecomment-1692900055) it seems like there's interest in passing shared contexts around in the raw API, this PR extracts just that aspect from #459 in so that at least the context aspect of #456 will be accepted.

Motivation: Passing a context around is necessary to allow `eq` and `hasher` to share the same mutable environment, Both can't implement `FnMut` and capture the same environment, because those two captures would both need to have exclusive access to it which is disallowed by Rust's aliasing rules.

There's three levels of possibly increasing controversy in this PR, separated by three commits:
* The first one introduces a context which is passed around through `*_with_context` methods, maintaining the same API in the process (`eq` is `impl FnMut`).
* The second commit makes both functions `impl Fn` for the new methods, meaning if you want to use a mutable shared environment there you *must* use the `&mut C` context variable to pass it around.
* The third commit makes the internals use function pointers, completely disallowing any context that is not explicitly passed through `&mut C`.

If there is interest in passing a context around like this, feel free to decide which one you want to keep, and which one to discard.

Thank you!