### PR TITLE
Gate tests behind basic checks passing first

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,17 @@ jobs:
         TARGET: i586-unknown-linux-gnu
       run: sh ci/tools.sh
 
+  basics:
+    runs-on: ubuntu-latest
+    needs:
+      - miri
+      - rustfmt_clippy
+    steps:
+      - run: exit 0
+
   test:
     runs-on: ${{ matrix.os }}
+    needs: basics
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Avoids running the full test matrix if basic inexpensive checks like formatting, clippy, or miri does not pass first.

I usually opt to put a simple `cargo check` or `cargo build` check in there too, but the `miri` job accomplishes most of that already and only has a two minute runtime. All though I'd be happy to break it up further if needed to speed up the total build.