### PR TITLE
Remove duplicate job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,9 +75,6 @@ jobs:
           channel: 1.64.0
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
-          channel: 1.64.0
-        - os: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
           channel: beta
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
This part was added in #347 to keep one CI builder at 1.56.1 for compatibility, but it's no longer relevant and doesn't do anything.
I noticed this when I was dealing with #460 but forgot to fix it.