### PR TITLE
Fix two bugs in `clone_from` one of which is mine 😅 (was introduced in  #458)

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,5 +1,5 @@
 use crate::alloc::alloc::{handle_alloc_error, Layout};
-use crate::scopeguard::guard;
+use crate::scopeguard::{guard, ScopeGuard};
 use crate::TryReserveError;
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
@@ -2824,7 +2824,7 @@ impl<T: Clone, A: Allocator + Clone> Clone for RawTable<T, A> {
                 self_.clone_from_spec(source);
 
                 // Disarm the scope guard if cloning was successful.
-                mem::forget(self_);
+                ScopeGuard::into_inner(self_);
             }
         }
     }

--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -25,7 +25,6 @@ impl<T, F> ScopeGuard<T, F>
 where
     F: FnMut(&mut T),
 {
-    #[allow(dead_code)]
     #[inline]
     pub fn into_inner(guard: Self) -> T {
         // Cannot move out of Drop-implementing types, so


### PR DESCRIPTION
My bad 😅, I totally forgot that we can modify table from another thread, which can result in an invalid `self` table in case if we have a panic during the cloning of elements (we will have an empty table with invalid control bytes to which we can get accessed via `RawIterRange` during parallel iteration or via the `find` function).
This pull request fixes my bug by partially reverting the old implementation of the `clone_from` function.

Also fixes leaking allocator when `self_.buckets() != source.buckets`. We used to rewrite the table (`&mut **self_ as *mut Self).write()`), forgetting that although we freed the old table memory, we forgot about the old allocator (**this behavior was found during testing**). Now, to allocate a new table, we use the old allocator, via `ptr::read(&self_.table.alloc)`.

The latter is worth thinking about. Maybe instead of using the old allocator, it's better to use the new one via `alloc.clone()` and just drop the old one?

**P.S.** Added tests for the cases described above. 
