### PR TITLE
Disable the use of NEON intrinsics on big-endian targets

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -24,7 +24,12 @@ cfg_if! {
     ))] {
         mod sse2;
         use sse2 as imp;
-    } else if #[cfg(all(target_arch = "aarch64", target_feature = "neon"))] {
+    } else if #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        // NEON intrinsics are currently broken on big-endian targets.
+        target_endian = "little",
+    ))] {
         mod neon;
         use neon as imp;
     } else {


### PR DESCRIPTION
These are implemented incorrectly in `core::arch`, and should therefore be avoided until they are fixed.