### PR TITLE
bump ahash version 0.8.0 -> 0.8.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.63.0"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.8.0", default-features = false, optional = true }
+ahash = { version = "0.8.6", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }


### PR DESCRIPTION
ahash 0.8.0 was yanked.

should also fix the issues mentioned in [hashbrown/issues/473](https://github.com/rust-lang/hashbrown/issues/473)

I think I ran all the necessary tests so let me know if I need to do more.

