### PR TITLE
Specialize `fold` implementation of iterators

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2469,6 +2469,14 @@ impl<K, V, A: Allocator> Iterator for IntoKeys<K, V, A> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, (k, _)| f(acc, k))
+    }
 }
 
 impl<K, V, A: Allocator> ExactSizeIterator for IntoKeys<K, V, A> {
@@ -2530,6 +2538,14 @@ impl<K, V, A: Allocator> Iterator for IntoValues<K, V, A> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+    #[inline]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, (_, v)| f(acc, v))
     }
 }
 
@@ -4722,6 +4738,17 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, x| unsafe {
+            let (k, v) = x.as_ref();
+            f(acc, (k, v))
+        })
+    }
 }
 impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
     #[cfg_attr(feature = "inline-more", inline)]
@@ -4749,6 +4776,17 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, x| unsafe {
+            let (k, v) = x.as_mut();
+            f(acc, (k, v))
+        })
     }
 }
 impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
@@ -4780,6 +4818,14 @@ impl<K, V, A: Allocator> Iterator for IntoIter<K, V, A> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, f)
+    }
 }
 impl<K, V, A: Allocator> ExactSizeIterator for IntoIter<K, V, A> {
     #[cfg_attr(feature = "inline-more", inline)]
@@ -4810,6 +4856,14 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, (k, _)| f(acc, k))
+    }
 }
 impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
     #[cfg_attr(feature = "inline-more", inline)]
@@ -4834,6 +4888,14 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, (_, v)| f(acc, v))
+    }
 }
 impl<K, V> ExactSizeIterator for Values<'_, K, V> {
     #[cfg_attr(feature = "inline-more", inline)]
@@ -4857,6 +4919,14 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, |acc, (_, v)| f(acc, v))
     }
 }
 impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
@@ -4885,6 +4955,14 @@ impl<'a, K, V, A: Allocator> Iterator for Drain<'a, K, V, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.inner.fold(init, f)
     }
 }
 impl<K, V, A: Allocator> ExactSizeIterator for Drain<'_, K, V, A> {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -50,35 +50,12 @@ use self::imp::Group;
 
 // Branch prediction hint. This is currently only available on nightly but it
 // consistently improves performance by 10-15%.
-// #[cfg(not(feature = "nightly"))]
-// use core::convert::identity as likely;
-// #[cfg(not(feature = "nightly"))]
-// use core::convert::identity as unlikely;
+#[cfg(not(feature = "nightly"))]
+use core::convert::identity as likely;
+#[cfg(not(feature = "nightly"))]
+use core::convert::identity as unlikely;
 #[cfg(feature = "nightly")]
 use core::intrinsics::{likely, unlikely};
-
-#[cfg(not(feature = "nightly"))]
-#[inline]
-#[cold]
-fn cold() {}
-
-#[cfg(not(feature = "nightly"))]
-#[inline]
-fn likely(b: bool) -> bool {
-    if !b {
-        cold()
-    }
-    b
-}
-#[cfg(not(feature = "nightly"))]
-#[cold]
-#[inline]
-fn unlikely(b: bool) -> bool {
-    if b {
-        cold()
-    }
-    b
-}
 
 // Use strict provenance functions if available.
 #[cfg(feature = "nightly")]

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3850,9 +3850,10 @@ impl<T> RawIterRange<T> {
     /// Folds every element into an accumulator by applying an operation,
     /// returning the final result.
     ///
-    /// `fold_impl()` takes three arguments: a number of items in the table, an initial value,
-    /// and a closure with two arguments: an 'accumulator', and an element. The closure
-    /// returns the value that the accumulator should have for the next iteration.
+    /// `fold_impl()` takes three arguments: the number of items remaining in
+    /// the iterator, an initial value, and a closure with two arguments: an
+    /// 'accumulator', and an element. The closure returns the value that the
+    /// accumulator should have for the next iteration.
     ///
     /// The initial value is the value the accumulator will have on the first call.
     ///
@@ -3877,10 +3878,6 @@ impl<T> RawIterRange<T> {
     where
         F: FnMut(B, Bucket<T>) -> B,
     {
-        if n == 0 {
-            return acc;
-        }
-
         loop {
             while let Some(index) = self.current_group.next() {
                 // The returned `index` will always be in the range `0..Group::WIDTH`,

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3847,8 +3847,30 @@ impl<T> RawIterRange<T> {
         }
     }
 
+    /// Folds every element into an accumulator by applying an operation,
+    /// returning the final result.
+    ///
+    /// `fold_impl()` takes three arguments: a number of items in the table, an initial value,
+    /// and a closure with two arguments: an 'accumulator', and an element. The closure
+    /// returns the value that the accumulator should have for the next iteration.
+    ///
+    /// The initial value is the value the accumulator will have on the first call.
+    ///
+    /// After applying this closure to every element of the iterator, `fold_impl()`
+    /// returns the accumulator.
+    ///
     /// # Safety
-    /// The provided `n` value must match the actual number of items
+    ///
+    /// If any of the following conditions are violated, the result is
+    /// [`Undefined Behavior`]:
+    ///
+    /// * The [`RawTableInner`] / [`RawTable`] must be alive and not moved,
+    ///   i.e. table outlives the `RawIterRange`;
+    ///
+    /// * The provided `n` value must match the actual number of items
+    ///   in the table.
+    ///
+    /// [`Undefined Behavior`]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[allow(clippy::while_let_on_iterator)]
     #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn fold_impl<F, B>(mut self, mut n: usize, mut acc: B, mut f: F) -> B
@@ -3861,6 +3883,8 @@ impl<T> RawIterRange<T> {
 
         loop {
             while let Some(index) = self.current_group.next() {
+                // The returned `index` will always be in the range `0..Group::WIDTH`,
+                // so that calling `self.data.next_n(index)` is safe (see detailed explanation below).
                 debug_assert!(n != 0);
                 let bucket = self.data.next_n(index);
                 acc = f(acc, bucket);
@@ -3871,11 +3895,34 @@ impl<T> RawIterRange<T> {
                 return acc;
             }
 
-            // We might read past self.end up to the next group boundary,
-            // but this is fine because it only occurs on tables smaller
-            // than the group size where the trailing control bytes are all
-            // EMPTY. On larger tables self.end is guaranteed to be aligned
-            // to the group size (since tables are power-of-two sized).
+            // SAFETY: The caller of this function ensures that:
+            //
+            // 1. The provided `n` value matches the actual number of items in the table;
+            // 2. The table is alive and did not moved.
+            //
+            // Taking the above into account, we always stay within the bounds, because:
+            //
+            // 1. For tables smaller than the group width (self.buckets() <= Group::WIDTH),
+            //    we will never end up in the given branch, since we should have already
+            //    yielded all the elements of the table.
+            //
+            // 2. For tables larger than the group width. The the number of buckets is a
+            //    power of two (2 ^ n), Group::WIDTH is also power of two (2 ^ k). Sinse
+            //    `(2 ^ n) > (2 ^ k)`, than `(2 ^ n) % (2 ^ k) = 0`. As we start from the
+            //    the start of the array of control bytes, and never try to iterate after
+            //    getting all the elements, the last `self.current_group` will read bytes
+            //    from the `self.buckets() - Group::WIDTH` index.  We know also that
+            //    `self.current_group.next()` will always retun indices within the range
+            //    `0..Group::WIDTH`.
+            //
+            //    Knowing all of the above and taking into account that we are synchronizing
+            //    the `self.data` index with the index we used to read the `self.current_group`,
+            //    the subsequent `self.data.next_n(index)` will always return a bucket with
+            //    an index number less than `self.buckets()`.
+            //
+            //    The last `self.next_ctrl`, whose index would be `self.buckets()`, will never
+            //    actually be read, since we should have already yielded all the elements of
+            //    the table.
             self.current_group = Group::load_aligned(self.next_ctrl).match_full().into_iter();
             self.data = self.data.next_n(Group::WIDTH);
             self.next_ctrl = self.next_ctrl.add(Group::WIDTH);

--- a/src/set.rs
+++ b/src/set.rs
@@ -1696,6 +1696,14 @@ impl<'a, K> Iterator for Iter<'a, K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
+    }
 }
 impl<'a, K> ExactSizeIterator for Iter<'a, K> {
     #[cfg_attr(feature = "inline-more", inline)]
@@ -1725,6 +1733,14 @@ impl<K, A: Allocator> Iterator for IntoIter<K, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, |acc, (k, ())| f(acc, k))
     }
 }
 impl<K, A: Allocator> ExactSizeIterator for IntoIter<K, A> {
@@ -1756,6 +1772,14 @@ impl<K, A: Allocator> Iterator for Drain<'_, K, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, |acc, (k, ())| f(acc, k))
     }
 }
 impl<K, A: Allocator> ExactSizeIterator for Drain<'_, K, A> {
@@ -1827,6 +1851,20 @@ where
         let (_, upper) = self.iter.size_hint();
         (0, upper)
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, |acc, elt| {
+            if self.other.contains(elt) {
+                f(acc, elt)
+            } else {
+                acc
+            }
+        })
+    }
 }
 
 impl<T, S, A> fmt::Debug for Intersection<'_, T, S, A>
@@ -1881,6 +1919,20 @@ where
         let (_, upper) = self.iter.size_hint();
         (0, upper)
     }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, |acc, elt| {
+            if self.other.contains(elt) {
+                acc
+            } else {
+                f(acc, elt)
+            }
+        })
+    }
 }
 
 impl<T, S, A> FusedIterator for Difference<'_, T, S, A>
@@ -1926,6 +1978,14 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
     }
 }
 
@@ -1991,6 +2051,14 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
+    }
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
     }
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1862,8 +1862,10 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // Avoid `Option::map` because it bloats LLVM IR.
-        let bucket = self.inner.next()?;
-        Some(unsafe { bucket.as_ref() })
+        match self.inner.next() {
+            Some(bucket) => Some(unsafe { bucket.as_ref() }),
+            None => None,
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1906,8 +1908,10 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // Avoid `Option::map` because it bloats LLVM IR.
-        let bucket = self.inner.next()?;
-        Some(unsafe { bucket.as_mut() })
+        match self.inner.next() {
+            Some(bucket) => Some(unsafe { bucket.as_mut() }),
+            None => None,
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
This provides 5-8% iteration speedups when using internal iteration.
Similar work could probably be done with `try_fold` but this requires `nightly` to implement.

Maybe this is worth running a rustc perf run with this before merge ?