### PR TITLE
Bump ahash to fix missing `stdsimd` with nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.63.0"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.8.6", default-features = false, optional = true }
+ahash = { version = "0.8.7", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }


### PR DESCRIPTION
Nightly https://github.com/rust-lang/rust/commit/ea37e8091fe87ae0a7e204c034e7d55061e56790 removed `stdsimd`, which ahash <= 0.8.6 depends on. This was fixed on ahash 0.8.7.