### PR TITLE
Backport #357 for 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.7.0", default-features = false, optional = true }
+ahash = { version = "0.8.0", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }
@@ -39,7 +39,8 @@ doc-comment = "0.3.1"
 [features]
 default = ["ahash", "inline-more"]
 
-ahash-compile-time-rng = ["ahash/compile-time-rng"]
+# Ahash changed behavior here, this feature is now a no-op for backcompat
+ahash-compile-time-rng = []
 nightly = []
 rustc-internal-api = []
 rustc-dep-of-std = [

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use core::ops::Index;
 
 /// Default hasher for `HashMap`.
 #[cfg(feature = "ahash")]
-pub type DefaultHashBuilder = ahash::RandomState;
+pub type DefaultHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
 
 /// Dummy default hasher for `HashMap`.
 #[cfg(not(feature = "ahash"))]


### PR DESCRIPTION
This backports the ahash bump to 0.12 (https://github.com/rust-lang/hashbrown/pull/357). It shouldn't be merged, instead it should be put in a branch/tag and released with a version bump (happy to update this PR to include a version bump if desired)


#497 is this PR for 0.11

A bunch of crates out there still use hashbrown at this version (Often via [`indexmap`](https://docs.rs/indexmap/1.9.3/indexmap/index.html), still used [by the wasmer ecosystem](https://docs.rs/wasmer-types/latest/wasmer_types/))


It would be nice to get a backport release here. A lot of these dependencies are deep in deptrees and will take time to upgrade.

I also have https://github.com/tkaitchuck/aHash/pull/202 open but it's unclear if that will land
