### PR TITLE
Bump ahash to 0.8.7 to fix broken nightly builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.63.0"
 
 [dependencies]
 # For the default hasher
-ahash = { version = "0.8.6", default-features = false, optional = true }
+ahash = { version = "0.8.7", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.0", optional = true }


### PR DESCRIPTION
Fixes #499 