### PR TITLE
Fix index calculation in panic guard of clone_from_impl

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,8 @@ jobs:
           armv7-unknown-linux-gnueabihf,
           aarch64-unknown-linux-gnu,
           thumbv6m-none-eabi,
-          x86_64-pc-windows-gnu,
+          # Disabled due to issues with cross-rs
+          #x86_64-pc-windows-gnu,
         ]
         channel: [1.74.0, nightly]
         include:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,8 +43,6 @@ jobs:
     - env:
         TARGET: ${{ matrix.target }}
         CHANNEL: ${{ matrix.channel }}
-        CROSS: ${{ matrix.target != 'x86_64-unknown-linux-gnu' && '1' || '0' }}
-        NO_STD: ${{ matrix.target == 'thumbv6m-none-eabi' && '1' || '0' }}
       run: sh ci/run.sh
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
           thumbv6m-none-eabi,
           x86_64-pc-windows-gnu,
         ]
-        channel: [1.72.0, nightly]
+        channel: [1.74.0, nightly]
         include:
         - os: macos-latest
           target: x86_64-apple-darwin
@@ -68,10 +68,10 @@ jobs:
           channel: nightly
         - os: macos-latest
           target: x86_64-apple-darwin
-          channel: 1.72.0
+          channel: 1.74.0
         - os: windows-latest
           target: x86_64-pc-windows-msvc
-          channel: 1.72.0
+          channel: 1.74.0
         - os: ubuntu-latest
           target: x86_64-unknown-linux-gnu
           channel: beta

--- a/src/map.rs
+++ b/src/map.rs
@@ -5,7 +5,7 @@ use crate::{Equivalent, TryReserveError};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::hash::{BuildHasher, Hash};
-use core::iter::{FromIterator, FusedIterator};
+use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::Index;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3582,7 +3582,7 @@ impl<T: Clone, A: Allocator + Clone> RawTable<T, A> {
         // cloned so far.
         let mut guard = guard((0, &mut *self), |(index, self_)| {
             if T::NEEDS_DROP {
-                for i in 0..=*index {
+                for i in 0..*index {
                     if self_.is_bucket_full(i) {
                         self_.bucket(i).drop();
                     }
@@ -3596,7 +3596,7 @@ impl<T: Clone, A: Allocator + Clone> RawTable<T, A> {
             to.write(from.as_ref().clone());
 
             // Update the index in case we need to unwind.
-            guard.0 = index;
+            guard.0 = index + 1;
         }
 
         // Successfully cloned all items, no need to clean up.

--- a/src/set.rs
+++ b/src/set.rs
@@ -4,7 +4,7 @@ use crate::{Equivalent, TryReserveError};
 use alloc::borrow::ToOwned;
 use core::fmt;
 use core::hash::{BuildHasher, Hash};
-use core::iter::{Chain, FromIterator, FusedIterator};
+use core::iter::{Chain, FusedIterator};
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
 
 use super::map::{self, DefaultHashBuilder, HashMap, Keys};


### PR DESCRIPTION
Previously, it was possible for an uninitialized element to be dropped if all of the following occurred:
- `clone_from` was called where `T: !Copy`.
- The `clone` implementation of `T` panicked.
- The first bucket of the source `HashMap` contained an entry.

Fixes #510 