### PR TITLE
feat: recognize and use over sized allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ serde_test = "1.0"
 doc-comment = "0.3.1"
 bumpalo = { version = "3.13.0", features = ["allocator-api2"] }
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2.155"
+
 [features]
 default = ["default-hasher", "inline-more", "allocator-api2", "equivalent", "raw-entry"]
 

--- a/benches/with_capacity.rs
+++ b/benches/with_capacity.rs
@@ -1,0 +1,38 @@
+#![feature(test)]
+
+extern crate test;
+
+use hashbrown::HashMap;
+use test::{black_box, Bencher};
+
+type Map<K, V> = HashMap<K, V>;
+
+macro_rules! bench_with_capacity {
+    ($name:ident, $cap:expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            b.iter(|| {
+                // Construct a new empty map with a given capacity and return it to avoid
+                // being optimized away. Dropping it measures allocation + minimal setup.
+                let m: Map<usize, usize> = Map::with_capacity($cap);
+                black_box(m)
+            });
+        }
+    };
+}
+
+bench_with_capacity!(with_capacity_000000, 0);
+bench_with_capacity!(with_capacity_000001, 1);
+bench_with_capacity!(with_capacity_000003, 3);
+bench_with_capacity!(with_capacity_000007, 7);
+bench_with_capacity!(with_capacity_000008, 8);
+bench_with_capacity!(with_capacity_000016, 16);
+bench_with_capacity!(with_capacity_000032, 32);
+bench_with_capacity!(with_capacity_000064, 64);
+bench_with_capacity!(with_capacity_000128, 128);
+bench_with_capacity!(with_capacity_000256, 256);
+bench_with_capacity!(with_capacity_000512, 512);
+bench_with_capacity!(with_capacity_001024, 1024);
+bench_with_capacity!(with_capacity_004096, 4096);
+bench_with_capacity!(with_capacity_016384, 16384);
+bench_with_capacity!(with_capacity_065536, 65536);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -148,7 +148,7 @@ fn capacity_to_buckets(cap: usize, table_layout: TableLayout) -> Option<usize> {
             16
         };
         ensure_bucket_bytes_at_least_ctrl_align(table_layout, buckets);
-        Some(buckets)
+        return Some(buckets);
     }
 
     // Otherwise require 1/8 buckets to be empty (87.5% load)


### PR DESCRIPTION
Allocators are allowed to return a larger memory chunk than was asked for. If the amount extra is large enough, then the hash table can use the extra space. The Global allocator will not hit this path, because it won't over-size enough to matter, but custom allocators may. An example of an allocator which allocates full system pages is included in the test suite (UNIX only because it uses `mmap`).

This implements #489. ~This relies on PR #524 to increase the minimum number of buckets for certain small types, which in turn constrains the domain of `maximum_buckets_in` so that the alignment can be ignored.~ Merged. 

~I haven't done any performance testing. Since this is on the slow path of making a new allocation, the feature should be doable without too much concern about overhead.~ There is a benchmark now you can run yourself, you can see the [numbers on my Apple M1 machine here](https://github.com/rust-lang/hashbrown/pull/523#issuecomment-3315091391). Since then, I added a fast-path shortcut which cuts this down when the system allocator is used (or when any allocator returns what was asked for).

I am definitely not an expert in swiss tables. Feedback is very welcome, even nitpicking.