### PR TITLE
Make equivalent default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bumpalo = { version = "3.13.0", features = ["allocator-api2"] }
 rkyv = { version = "0.7.42", features = ["validation"] }
 
 [features]
-default = ["ahash", "inline-more", "allocator-api2"]
+default = ["ahash", "inline-more", "allocator-api2", "equivalent"]
 
 nightly = ["allocator-api2?/nightly", "bumpalo/allocator_api"]
 


### PR DESCRIPTION
I think this is how it is meant to be:

https://github.com/rust-lang/hashbrown/blob/e25e6bb02e4fe4d58835f525d60f86091f41d50f/src/lib.rs#L140-L142

CC @cuviper 