### PR TITLE
Replace "ahash" with "default-hasher" in Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.25", default-features = false, optional = true }
 rkyv = { version = "0.7.42", optional = true, default-features = false, features = [
     "alloc",
 ] }
+borsh = { version = "1.5.0", default-features = false, optional = true, features = ["derive"]}
 
 # When built as part of libstd
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
@@ -36,9 +37,6 @@ allocator-api2 = { version = "0.2.9", optional = true, default-features = false,
 # Equivalent trait which can be shared with other hash table implementations.
 equivalent = { version = "1.0", optional = true, default-features = false }
 
-# borsh serde
-borsh = { version = "1.5.0", default-features = false, optional = true, features = ["derive"]}
-
 [dev-dependencies]
 lazy_static = "1.4"
 rand = { version = "0.8.3", features = ["small_rng"] }
@@ -50,11 +48,16 @@ bumpalo = { version = "3.13.0", features = ["allocator-api2"] }
 rkyv = { version = "0.7.42", features = ["validation"] }
 
 [features]
-default = ["ahash", "inline-more", "allocator-api2", "equivalent"]
+default = ["default-hasher", "inline-more", "allocator-api2", "equivalent"]
 
+# Enables use of nightly features. This is only guaranteed to work on the latest
+# version of nightly Rust.
 nightly = ["allocator-api2?/nightly", "bumpalo/allocator_api"]
 
+# Enables the RustcEntry API used to provide the standard library's Entry API.
 rustc-internal-api = []
+
+# Internal feature used when building as part of the standard library.
 rustc-dep-of-std = [
     "nightly",
     "core",
@@ -62,14 +65,19 @@ rustc-dep-of-std = [
     "alloc",
     "rustc-internal-api",
 ]
+
+# Enables the RawTable API.
 raw = []
+
+# Provides a default hasher. Currently this is AHash but this is subject to
+# change in the future. Note that the default hasher does *not* provide HashDoS
+# resistance, unlike the one in the standard library.
+default-hasher = ["dep:ahash"]
 
 # Enables usage of `#[inline]` on far more functions than by default in this
 # crate. This may lead to a performance increase but often comes at a compile
 # time cost.
 inline-more = []
-
-borsh = ["dep:borsh"]
 
 [package.metadata.docs.rs]
 features = ["nightly", "rayon", "serde", "raw"]

--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ This crate has the following Cargo features:
 
 - `nightly`: Enables nightly-only features including: `#[may_dangle]`.
 - `serde`: Enables serde serialization support.
+- `borsh`: Enables borsh serialization support.
 - `rkyv`: Enables rkyv serialization support.
 - `rayon`: Enables rayon parallel iterator support.
+- `equivalent`: Allows comparisons to be customized with the `Equivalent` trait.
 - `raw`: Enables access to the experimental and unsafe `RawTable` API.
 - `inline-more`: Adds inline hints to most functions, improving run-time performance at the cost
   of compilation time. (enabled by default)
-- `ahash`: Compiles with ahash as default hasher. (enabled by default)
+- `default-hasher`: Compiles with ahash as default hasher. (enabled by default)
 - `allocator-api2`: Enables support for allocators that support `allocator-api2`. (enabled by default)
 
 ## License

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -8,7 +8,7 @@ extern crate test;
 
 use test::{black_box, Bencher};
 
-use hashbrown::hash_map::DefaultHashBuilder;
+use hashbrown::DefaultHashBuilder;
 use hashbrown::{HashMap, HashSet};
 use std::{
     collections::hash_map::RandomState,

--- a/src/external_trait_impls/rayon/table.rs
+++ b/src/external_trait_impls/rayon/table.rs
@@ -215,10 +215,7 @@ mod test_par_table {
 
     use rayon::prelude::*;
 
-    use crate::{
-        hash_map::{make_hash, DefaultHashBuilder},
-        hash_table::HashTable,
-    };
+    use crate::{hash_map::make_hash, hash_table::HashTable, DefaultHashBuilder};
 
     #[test]
     fn test_iterate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,14 @@
 #![cfg_attr(feature = "nightly", warn(fuzzy_provenance_casts))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 
+/// Default hasher for [`HashMap`], [`HashSet`] and [`HashTable`].
+#[cfg(feature = "default-hasher")]
+pub type DefaultHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
+
+/// Dummy default hasher for [`HashMap`], [`HashSet`] and [`HashTable`].
+#[cfg(not(feature = "default-hasher"))]
+pub enum DefaultHashBuilder {}
+
 #[cfg(test)]
 #[macro_use]
 extern crate std;

--- a/src/map.rs
+++ b/src/map.rs
@@ -11,11 +11,11 @@ use core::mem;
 use core::ops::Index;
 
 /// Default hasher for `HashMap`.
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 pub type DefaultHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
 
 /// Dummy default hasher for `HashMap`.
-#[cfg(not(feature = "ahash"))]
+#[cfg(not(feature = "default-hasher"))]
 pub enum DefaultHashBuilder {}
 
 /// A hash map implemented with quadratic probing and SIMD lookup.
@@ -262,7 +262,7 @@ where
     hash_builder.hash_one(val)
 }
 
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 impl<K, V> HashMap<K, V, DefaultHashBuilder> {
     /// Creates an empty `HashMap`.
     ///
@@ -325,7 +325,7 @@ impl<K, V> HashMap<K, V, DefaultHashBuilder> {
     }
 }
 
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 impl<K, V, A: Allocator> HashMap<K, V, DefaultHashBuilder, A> {
     /// Creates an empty `HashMap` using the given allocator.
     ///
@@ -2258,7 +2258,7 @@ where
 }
 
 // The default hasher is used to match the std implementation signature
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 impl<K, V, A, const N: usize> From<[(K, V); N]> for HashMap<K, V, DefaultHashBuilder, A>
 where
     K: Eq + Hash,

--- a/src/map.rs
+++ b/src/map.rs
@@ -6718,7 +6718,6 @@ mod test_map {
     use rand::{rngs::SmallRng, Rng, SeedableRng};
     use std::borrow::ToOwned;
     use std::cell::RefCell;
-    use std::usize;
     use std::vec::Vec;
 
     #[test]

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,7 @@
 use crate::raw::{
     Allocator, Bucket, Global, RawDrain, RawExtractIf, RawIntoIter, RawIter, RawTable,
 };
-use crate::{Equivalent, TryReserveError};
+use crate::{DefaultHashBuilder, Equivalent, TryReserveError};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::hash::{BuildHasher, Hash};
@@ -9,14 +9,6 @@ use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::Index;
-
-/// Default hasher for `HashMap`.
-#[cfg(feature = "default-hasher")]
-pub type DefaultHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
-
-/// Dummy default hasher for `HashMap`.
-#[cfg(not(feature = "default-hasher"))]
-pub enum DefaultHashBuilder {}
 
 /// A hash map implemented with quadratic probing and SIMD lookup.
 ///
@@ -447,7 +439,7 @@ impl<K, V, S> HashMap<K, V, S> {
     ///
     /// ```
     /// use hashbrown::HashMap;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut map = HashMap::with_hasher(s);
@@ -489,7 +481,7 @@ impl<K, V, S> HashMap<K, V, S> {
     ///
     /// ```
     /// use hashbrown::HashMap;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut map = HashMap::with_capacity_and_hasher(10, s);
@@ -535,7 +527,7 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     ///
     /// ```
     /// use hashbrown::HashMap;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut map = HashMap::with_hasher(s);
@@ -570,7 +562,7 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     ///
     /// ```
     /// use hashbrown::HashMap;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut map = HashMap::with_capacity_and_hasher(10, s);
@@ -592,7 +584,7 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     ///
     /// ```
     /// use hashbrown::HashMap;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let hasher = DefaultHashBuilder::default();
     /// let map: HashMap<i32, i32> = HashMap::with_hasher(hasher);

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -483,7 +483,7 @@ impl<T> Bucket<T> {
     /// use core::hash::{BuildHasher, Hash};
     /// use hashbrown::raw::{Bucket, RawTable};
     ///
-    /// type NewHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
+    /// type NewHashBuilder = hashbrown::DefaultHashBuilder;
     ///
     /// fn make_hash<K: Hash + ?Sized, S: BuildHasher>(hash_builder: &S, key: &K) -> u64 {
     ///     use core::hash::Hasher;
@@ -649,7 +649,7 @@ impl<T> Bucket<T> {
     /// use core::hash::{BuildHasher, Hash};
     /// use hashbrown::raw::{Bucket, RawTable};
     ///
-    /// type NewHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
+    /// type NewHashBuilder = hashbrown::DefaultHashBuilder;
     ///
     /// fn make_hash<K: Hash + ?Sized, S: BuildHasher>(hash_builder: &S, key: &K) -> u64 {
     ///     use core::hash::Hasher;
@@ -708,7 +708,7 @@ impl<T> Bucket<T> {
     /// use core::hash::{BuildHasher, Hash};
     /// use hashbrown::raw::{Bucket, RawTable};
     ///
-    /// type NewHashBuilder = core::hash::BuildHasherDefault<ahash::AHasher>;
+    /// type NewHashBuilder = hashbrown::DefaultHashBuilder;
     ///
     /// fn make_hash<K: Hash + ?Sized, S: BuildHasher>(hash_builder: &S, key: &K) -> u64 {
     ///     use core::hash::Hasher;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1235,7 +1235,7 @@ impl<T, A: Allocator> RawTable<T, A> {
                 fallibility,
                 Self::TABLE_LAYOUT,
                 if T::NEEDS_DROP {
-                    Some(mem::transmute(ptr::drop_in_place::<T> as unsafe fn(*mut T)))
+                    Some(|ptr| ptr::drop_in_place(ptr as *mut T))
                 } else {
                     None
                 },
@@ -2911,7 +2911,7 @@ impl RawTableInner {
         hasher: &dyn Fn(&mut Self, usize) -> u64,
         fallibility: Fallibility,
         layout: TableLayout,
-        drop: Option<fn(*mut u8)>,
+        drop: Option<unsafe fn(*mut u8)>,
     ) -> Result<(), TryReserveError>
     where
         A: Allocator,
@@ -3145,7 +3145,7 @@ impl RawTableInner {
         &mut self,
         hasher: &dyn Fn(&mut Self, usize) -> u64,
         size_of: usize,
-        drop: Option<fn(*mut u8)>,
+        drop: Option<unsafe fn(*mut u8)>,
     ) {
         // If the hash function panics then properly clean up any elements
         // that we haven't rehashed yet. We unfortunately can't preserve the
@@ -4577,7 +4577,7 @@ mod test_map {
                 &|table, index| hasher(table.bucket::<T>(index).as_ref()),
                 mem::size_of::<T>(),
                 if mem::needs_drop::<T>() {
-                    Some(mem::transmute(ptr::drop_in_place::<T> as unsafe fn(*mut T)))
+                    Some(|ptr| ptr::drop_in_place(ptr as *mut T))
                 } else {
                     None
                 },

--- a/src/set.rs
+++ b/src/set.rs
@@ -128,7 +128,7 @@ impl<T: Clone, S: Clone, A: Allocator + Clone> Clone for HashSet<T, S, A> {
     }
 }
 
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 impl<T> HashSet<T, DefaultHashBuilder> {
     /// Creates an empty `HashSet`.
     ///
@@ -192,7 +192,7 @@ impl<T> HashSet<T, DefaultHashBuilder> {
     }
 }
 
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 impl<T: Hash + Eq, A: Allocator> HashSet<T, DefaultHashBuilder, A> {
     /// Creates an empty `HashSet`.
     ///
@@ -1324,7 +1324,7 @@ where
 }
 
 // The default hasher is used to match the std implementation signature
-#[cfg(feature = "ahash")]
+#[cfg(feature = "default-hasher")]
 impl<T, A, const N: usize> From<[T; N]> for HashSet<T, DefaultHashBuilder, A>
 where
     T: Eq + Hash,

--- a/src/set.rs
+++ b/src/set.rs
@@ -7,8 +7,9 @@ use core::hash::{BuildHasher, Hash};
 use core::iter::{Chain, FusedIterator};
 use core::ops::{BitAnd, BitOr, BitXor, Sub};
 
-use super::map::{self, DefaultHashBuilder, HashMap, Keys};
+use super::map::{self, HashMap, Keys};
 use crate::raw::{Allocator, Global, RawExtractIf};
+use crate::DefaultHashBuilder;
 
 // Future Optimization (FIXME!)
 // =============================
@@ -459,7 +460,7 @@ impl<T, S> HashSet<T, S, Global> {
     ///
     /// ```
     /// use hashbrown::HashSet;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut set = HashSet::with_hasher(s);
@@ -497,7 +498,7 @@ impl<T, S> HashSet<T, S, Global> {
     ///
     /// ```
     /// use hashbrown::HashSet;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut set = HashSet::with_capacity_and_hasher(10, s);
@@ -546,7 +547,7 @@ where
     ///
     /// ```
     /// use hashbrown::HashSet;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut set = HashSet::with_hasher(s);
@@ -584,7 +585,7 @@ where
     ///
     /// ```
     /// use hashbrown::HashSet;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let s = DefaultHashBuilder::default();
     /// let mut set = HashSet::with_capacity_and_hasher(10, s);
@@ -605,7 +606,7 @@ where
     ///
     /// ```
     /// use hashbrown::HashSet;
-    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use hashbrown::DefaultHashBuilder;
     ///
     /// let hasher = DefaultHashBuilder::default();
     /// let set: HashSet<i32> = HashSet::with_hasher(hasher);
@@ -2497,8 +2498,8 @@ fn assert_covariance() {
 
 #[cfg(test)]
 mod test_set {
-    use super::super::map::DefaultHashBuilder;
     use super::HashSet;
+    use crate::DefaultHashBuilder;
     use std::vec::Vec;
 
     #[test]

--- a/src/table.rs
+++ b/src/table.rs
@@ -103,14 +103,13 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use bumpalo::Bump;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let bump = Bump::new();
     /// let mut table = HashTable::new_in(&bump);
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// // The created HashTable holds none elements
@@ -147,14 +146,13 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use bumpalo::Bump;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let bump = Bump::new();
     /// let mut table = HashTable::with_capacity_in(5, &bump);
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// // The created HashTable holds none elements
@@ -203,12 +201,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), 1, hasher);
     /// table.insert_unique(hasher(&2), 2, hasher);
@@ -241,12 +238,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), (1, "a"), |val| hasher(&val.0));
     /// if let Some(val) = table.find_mut(hasher(&1), |val| val.0 == 1) {
@@ -280,12 +276,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), (1, "a"), |val| hasher(&val.0));
     /// if let Ok(entry) = table.find_entry(hasher(&1), |val| val.0 == 1) {
@@ -335,13 +330,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), (1, "a"), |val| hasher(&val.0));
     /// if let Entry::Occupied(entry) = table.entry(hasher(&1), |val| val.0 == 1, |val| hasher(&val.0))
@@ -392,12 +386,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut v = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// v.insert_unique(hasher(&1), 1, hasher);
     /// # }
@@ -427,12 +420,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut v = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// v.insert_unique(hasher(&1), 1, hasher);
     /// v.clear();
@@ -459,12 +451,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::with_capacity(100);
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), 1, hasher);
     /// table.insert_unique(hasher(&2), 2, hasher);
@@ -496,12 +487,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::with_capacity(100);
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), 1, hasher);
     /// table.insert_unique(hasher(&2), 2, hasher);
@@ -541,12 +531,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<i32> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.reserve(10, hasher);
     /// assert!(table.capacity() >= 10);
@@ -577,12 +566,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<i32> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table
     ///     .try_reserve(10, hasher)
@@ -621,11 +609,10 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// let mut v = HashTable::new();
     /// assert_eq!(v.len(), 0);
@@ -648,11 +635,10 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// let mut v = HashTable::new();
     /// assert!(v.is_empty());
@@ -676,12 +662,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&"a"), "b", hasher);
     /// table.insert_unique(hasher(&"b"), "b", hasher);
@@ -712,12 +697,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&1), 1, hasher);
     /// table.insert_unique(hasher(&2), 2, hasher);
@@ -764,12 +748,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// for x in 1..=6 {
     ///     table.insert_unique(hasher(&x), x, hasher);
@@ -800,12 +783,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// for x in 1..=3 {
     ///     table.insert_unique(hasher(&x), x, hasher);
@@ -847,12 +829,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// for x in 0..8 {
     ///     table.insert_unique(hasher(&x), x, hasher);
@@ -899,13 +880,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut libraries: HashTable<(&str, u32)> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// for (k, v) in [
     ///     ("Bodleian Library", 1602),
@@ -969,13 +949,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut libraries: HashTable<(&str, u32)> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// for (k, v) in [
     ///     ("Bodleian Library", 1602),
@@ -1100,12 +1079,12 @@ where
 /// ```
 /// # #[cfg(feature = "nightly")]
 /// # fn test() {
-/// use ahash::AHasher;
-/// use hashbrown::hash_table::{Entry, HashTable, OccupiedEntry};
-/// use std::hash::{BuildHasher, BuildHasherDefault};
+/// use hashbrown::hash_table::{Entry, OccupiedEntry};
+/// use hashbrown::{HashTable, DefaultHashBuilder};
+/// use std::hash::BuildHasher;
 ///
 /// let mut table = HashTable::new();
-/// let hasher = BuildHasherDefault::<AHasher>::default();
+/// let hasher = DefaultHashBuilder::default();
 /// let hasher = |val: &_| hasher.hash_one(val);
 /// for x in ["a", "b", "c"] {
 ///     table.insert_unique(hasher(&x), x, hasher);
@@ -1152,12 +1131,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::hash_table::{Entry, HashTable, OccupiedEntry};
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::hash_table::{Entry, OccupiedEntry};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// for x in ["a", "b"] {
     ///     table.insert_unique(hasher(&x), x, hasher);
@@ -1182,12 +1161,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::hash_table::{Entry, HashTable, OccupiedEntry};
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::hash_table::{Entry, OccupiedEntry};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table = HashTable::<&str>::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// match table.entry(hasher(&"a"), |&x| x == "a", hasher) {
@@ -1224,12 +1203,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<&str> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// let entry = table
@@ -1262,12 +1240,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<&str> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// // nonexistent key
@@ -1308,12 +1285,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<String> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// table
@@ -1344,12 +1320,11 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<(&str, u32)> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// table
@@ -1404,12 +1379,12 @@ where
 /// ```
 /// # #[cfg(feature = "nightly")]
 /// # fn test() {
-/// use ahash::AHasher;
-/// use hashbrown::hash_table::{Entry, HashTable, OccupiedEntry};
-/// use std::hash::{BuildHasher, BuildHasherDefault};
+/// use hashbrown::hash_table::{Entry, OccupiedEntry};
+/// use hashbrown::{HashTable, DefaultHashBuilder};
+/// use std::hash::BuildHasher;
 ///
 /// let mut table = HashTable::new();
-/// let hasher = BuildHasherDefault::<AHasher>::default();
+/// let hasher = DefaultHashBuilder::default();
 /// let hasher = |val: &_| hasher.hash_one(val);
 /// for x in ["a", "b", "c"] {
 ///     table.insert_unique(hasher(&x), x, hasher);
@@ -1487,13 +1462,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<&str> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// // The table is empty
     /// assert!(table.is_empty() && table.capacity() == 0);
@@ -1536,13 +1510,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<&str> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&"poneyland"), "poneyland", hasher);
     ///
@@ -1573,13 +1546,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<(&str, u32)> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&"poneyland"), ("poneyland", 12), |(k, _)| hasher(&k));
     ///
@@ -1627,13 +1599,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<(&str, u32)> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     /// table.insert_unique(hasher(&"poneyland"), ("poneyland", 12), |(k, _)| hasher(&k));
     ///
@@ -1684,12 +1655,12 @@ where
 /// ```
 /// # #[cfg(feature = "nightly")]
 /// # fn test() {
-/// use ahash::AHasher;
-/// use hashbrown::hash_table::{Entry, HashTable, VacantEntry};
-/// use std::hash::{BuildHasher, BuildHasherDefault};
+/// use hashbrown::hash_table::{Entry, VacantEntry};
+/// use hashbrown::{HashTable, DefaultHashBuilder};
+/// use std::hash::BuildHasher;
 ///
 /// let mut table: HashTable<&str> = HashTable::new();
-/// let hasher = BuildHasherDefault::<AHasher>::default();
+/// let hasher = DefaultHashBuilder::default();
 /// let hasher = |val: &_| hasher.hash_one(val);
 ///
 /// let entry_v: VacantEntry<_, _> = match table.entry(hasher(&"a"), |&x| x == "a", hasher) {
@@ -1742,13 +1713,12 @@ where
     /// ```
     /// # #[cfg(feature = "nightly")]
     /// # fn test() {
-    /// use ahash::AHasher;
     /// use hashbrown::hash_table::Entry;
-    /// use hashbrown::HashTable;
-    /// use std::hash::{BuildHasher, BuildHasherDefault};
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
     ///
     /// let mut table: HashTable<&str> = HashTable::new();
-    /// let hasher = BuildHasherDefault::<AHasher>::default();
+    /// let hasher = DefaultHashBuilder::default();
     /// let hasher = |val: &_| hasher.hash_one(val);
     ///
     /// if let Entry::Vacant(o) = table.entry(hasher(&"poneyland"), |&x| x == "poneyland", hasher) {
@@ -1798,12 +1768,12 @@ where
 /// ```
 /// # #[cfg(feature = "nightly")]
 /// # fn test() {
-/// use ahash::AHasher;
-/// use hashbrown::hash_table::{AbsentEntry, Entry, HashTable};
-/// use std::hash::{BuildHasher, BuildHasherDefault};
+/// use hashbrown::hash_table::{AbsentEntry, Entry};
+/// use hashbrown::{HashTable, DefaultHashBuilder};
+/// use std::hash::BuildHasher;
 ///
 /// let mut table: HashTable<&str> = HashTable::new();
-/// let hasher = BuildHasherDefault::<AHasher>::default();
+/// let hasher = DefaultHashBuilder::default();
 /// let hasher = |val: &_| hasher.hash_one(val);
 ///
 /// let entry_v: AbsentEntry<_, _> = table.find_entry(hasher(&"a"), |&x| x == "a").unwrap_err();

--- a/tests/hasher.rs
+++ b/tests/hasher.rs
@@ -23,7 +23,7 @@ fn check<S: BuildHasher + Default>() {
 /// Use hashbrown's default hasher.
 #[test]
 fn default() {
-    check::<hashbrown::hash_map::DefaultHashBuilder>();
+    check::<hashbrown::DefaultHashBuilder>();
 }
 
 /// Use std's default hasher.

--- a/tests/hasher.rs
+++ b/tests/hasher.rs
@@ -11,13 +11,13 @@ fn check<S: BuildHasher + Default>() {
     let mut set = HashSet::<i32, S>::default();
     set.extend(range.clone());
 
-    assert!(!set.contains(&i32::min_value()));
+    assert!(!set.contains(&i32::MIN));
     assert!(!set.contains(&(range.start - 1)));
     for i in range.clone() {
         assert!(set.contains(&i));
     }
     assert!(!set.contains(&range.end));
-    assert!(!set.contains(&i32::max_value()));
+    assert!(!set.contains(&i32::MAX));
 }
 
 /// Use hashbrown's default hasher.
@@ -56,7 +56,7 @@ fn max() {
 
     impl Hasher for MaxHasher {
         fn finish(&self) -> u64 {
-            u64::max_value()
+            u64::MAX
         }
         fn write(&mut self, _: &[u8]) {}
     }


### PR DESCRIPTION
This allows us to change the default hasher in the future without it being a breaking change.