### PR TITLE
Fix link to std traits in docs

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -42,6 +42,8 @@ use crate::{
 ///
 /// [`HashMap`]: super::HashMap
 /// [`HashSet`]: super::HashSet
+/// [`Eq`]: https://doc.rust-lang.org/std/cmp/trait.Eq.html
+/// [`Hash`]: https://doc.rust-lang.org/std/hash/trait.Hash.html
 pub struct HashTable<T, A = Global>
 where
     A: Allocator,


### PR DESCRIPTION
Link to `Hash` in docs for `HashTable` was pointing to `Hash` derive macro, rather than `Hash` trait.