### PR TITLE
Implement Default for iterators

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2447,6 +2447,14 @@ pub struct IntoKeys<K, V, A: Allocator = Global> {
     inner: IntoIter<K, V, A>,
 }
 
+impl<K, V, A: Allocator> Default for IntoKeys<K, V, A> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
 impl<K, V, A: Allocator> Iterator for IntoKeys<K, V, A> {
     type Item = K;
 
@@ -2517,6 +2525,14 @@ pub struct IntoValues<K, V, A: Allocator = Global> {
     inner: IntoIter<K, V, A>,
 }
 
+impl<K, V, A: Allocator> Default for IntoValues<K, V, A> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
 impl<K, V, A: Allocator> Iterator for IntoValues<K, V, A> {
     type Item = V;
 
@@ -4720,6 +4736,15 @@ impl<K, V, S, A: Allocator> IntoIterator for HashMap<K, V, S, A> {
     }
 }
 
+impl<'a, K, V> Default for Iter<'a, K, V> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            marker: PhantomData,
+        }
+    }
+}
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
@@ -4759,6 +4784,15 @@ impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
 
 impl<K, V> FusedIterator for Iter<'_, K, V> {}
 
+impl<'a, K, V> Default for IterMut<'a, K, V> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            marker: PhantomData,
+        }
+    }
+}
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 
@@ -4807,6 +4841,14 @@ where
     }
 }
 
+impl<K, V, A: Allocator> Default for IntoIter<K, V, A> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
 impl<K, V, A: Allocator> Iterator for IntoIter<K, V, A> {
     type Item = (K, V);
 
@@ -4841,6 +4883,14 @@ impl<K: Debug, V: Debug, A: Allocator> fmt::Debug for IntoIter<K, V, A> {
     }
 }
 
+impl<'a, K, V> Default for Keys<'a, K, V> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
@@ -4873,6 +4923,14 @@ impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
 }
 impl<K, V> FusedIterator for Keys<'_, K, V> {}
 
+impl<'a, K, V> Default for Values<'a, K, V> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
 impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
@@ -4905,6 +4963,14 @@ impl<K, V> ExactSizeIterator for Values<'_, K, V> {
 }
 impl<K, V> FusedIterator for Values<'_, K, V> {}
 
+impl<'a, K, V> Default for ValuesMut<'a, K, V> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -4112,6 +4112,13 @@ impl<T> Clone for RawIter<T> {
         }
     }
 }
+impl<T> Default for RawIter<T> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        // SAFETY: Because the table is static, it always outlives the iter.
+        unsafe { RawTableInner::NEW.iter() }
+    }
+}
 
 impl<T> Iterator for RawIter<T> {
     type Item = Bucket<T>;
@@ -4330,6 +4337,15 @@ impl<T, A: Allocator> Drop for RawIntoIter<T, A> {
     }
 }
 
+impl<T, A: Allocator> Default for RawIntoIter<T, A> {
+    fn default() -> Self {
+        Self {
+            iter: Default::default(),
+            allocation: None,
+            marker: PhantomData,
+        }
+    }
+}
 impl<T, A: Allocator> Iterator for RawIntoIter<T, A> {
     type Item = T;
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1832,6 +1832,14 @@ impl<K> Clone for Iter<'_, K> {
         }
     }
 }
+impl<K> Default for Iter<'_, K> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Iter {
+            iter: Default::default(),
+        }
+    }
+}
 impl<'a, K> Iterator for Iter<'a, K> {
     type Item = &'a K;
 
@@ -1866,6 +1874,14 @@ impl<K: fmt::Debug> fmt::Debug for Iter<'_, K> {
     }
 }
 
+impl<K, A: Allocator> Default for IntoIter<K, A> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        IntoIter {
+            iter: Default::default(),
+        }
+    }
+}
 impl<K, A: Allocator> Iterator for IntoIter<K, A> {
     type Item = K;
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1835,6 +1835,15 @@ pub struct Iter<'a, T> {
     marker: PhantomData<&'a T>,
 }
 
+impl<'a, T> Default for Iter<'a, T> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        Iter {
+            inner: Default::default(),
+            marker: PhantomData,
+        }
+    }
+}
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
@@ -1881,6 +1890,15 @@ pub struct IterMut<'a, T> {
     marker: PhantomData<&'a mut T>,
 }
 
+impl<'a, T> Default for IterMut<'a, T> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        IterMut {
+            inner: Default::default(),
+            marker: PhantomData,
+        }
+    }
+}
 impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
@@ -1931,6 +1949,14 @@ where
     inner: RawIntoIter<T, A>,
 }
 
+impl<T, A: Allocator> Default for IntoIter<T, A> {
+    #[cfg_attr(feature = "inline-more", inline)]
+    fn default() -> Self {
+        IntoIter {
+            inner: Default::default(),
+        }
+    }
+}
 impl<T, A> Iterator for IntoIter<T, A>
 where
     A: Allocator,


### PR DESCRIPTION
See rust-lang/rust#128261 for a similar PR for some libstd iterators. In order to do a similar PR for the `HashSet` and `HashMap` types, we need to make these changes to `hashbrown` first to actually implement them.

One small caveat is that I chose to only implement `Default` for `RawIter` and not `RawIterRange`, since it really exists as an implementation detail anyway, and the best implementation would involve just using the `RawIter` implementation anyway.