### PR TITLE
Implement `Clone`, `Debug` for iterators

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2399,6 +2399,7 @@ impl<K, V> IterMut<'_, K, V> {
 /// assert_eq!(iter.next(), None);
 /// assert_eq!(iter.next(), None);
 /// ```
+#[derive(Clone)]
 pub struct IntoIter<K, V, A: Allocator = Global> {
     inner: RawIntoIter<(K, V), A>,
 }
@@ -2443,6 +2444,7 @@ impl<K, V, A: Allocator> IntoIter<K, V, A> {
 /// assert_eq!(keys.next(), None);
 /// assert_eq!(keys.next(), None);
 /// ```
+#[derive(Clone)]
 pub struct IntoKeys<K, V, A: Allocator = Global> {
     inner: IntoIter<K, V, A>,
 }
@@ -2521,6 +2523,7 @@ impl<K: Debug, V: Debug, A: Allocator> fmt::Debug for IntoKeys<K, V, A> {
 /// assert_eq!(values.next(), None);
 /// assert_eq!(values.next(), None);
 /// ```
+#[derive(Clone)]
 pub struct IntoValues<K, V, A: Allocator = Global> {
     inner: IntoIter<K, V, A>,
 }

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -4280,6 +4280,7 @@ impl ExactSizeIterator for FullBucketsIndices {}
 impl FusedIterator for FullBucketsIndices {}
 
 /// Iterator which consumes a table and returns elements.
+#[derive(Clone)]
 pub struct RawIntoIter<T, A: Allocator = Global> {
     iter: RawIter<T>,
     allocation: Option<(NonNull<u8>, Layout, A)>,

--- a/src/set.rs
+++ b/src/set.rs
@@ -1701,6 +1701,7 @@ pub struct Iter<'a, K> {
 ///
 /// [`HashSet`]: struct.HashSet.html
 /// [`into_iter`]: struct.HashSet.html#method.into_iter
+#[derive(Clone)]
 pub struct IntoIter<K, A: Allocator = Global> {
     iter: map::IntoIter<K, (), A>,
 }


### PR DESCRIPTION
Follow-up to #542 after I noticed these were missing too. A more complete implementation of #541.

Adds:

* explicit `Clone` for `raw::Iter` and `raw::IntoIter`
* derived `Clone` for iterators that use `raw::IntoIter` internally
* explicit `Debug` implementations for `raw::Iter`, `raw::IterMut`, and `raw::IntoIter`
* public `iter` and `iter_mut` methods to `raw::IntoIter` (only `iter` is needed for `Debug`, but I decided to add these as public since map and set `IntoIter` seem to have public `iter` methods)