### PR TITLE
Fix `--no-default-features` without `--features raw-entry`

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -43,8 +43,8 @@ if [ "${CHANNEL}" = "nightly" ]; then
 fi
 
 # Make sure we can compile without the default hasher
-"${CARGO}" -vv build --target="${TARGET}" --no-default-features --features raw-entry
-"${CARGO}" -vv build --target="${TARGET}" --release --no-default-features --features raw-entry
+"${CARGO}" -vv build --target="${TARGET}" --no-default-features
+"${CARGO}" -vv build --target="${TARGET}" --release --no-default-features
 
 "${CARGO}" -vv ${OP} --target="${TARGET}"
 "${CARGO}" -vv ${OP} --target="${TARGET}" --features "${FEATURES}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ mod raw;
 
 mod external_trait_impls;
 mod map;
-#[cfg(feature = "raw-entry")]
+// FIXME: gate this entire module when `HashSet` stops using it
+// #[cfg(feature = "raw-entry")]
 mod raw_entry;
 #[cfg(feature = "rustc-internal-api")]
 mod rustc_entry;

--- a/src/raw_entry.rs
+++ b/src/raw_entry.rs
@@ -1,3 +1,6 @@
+// FIXME: When not public, a lot is dead because `HashSet` only uses a fraction of the API
+#![cfg_attr(not(feature = "raw-entry"), allow(dead_code))]
+
 use crate::hash_map::{equivalent, make_hash, make_hasher};
 use crate::raw::{Allocator, Bucket, Global, RawTable};
 use crate::{Equivalent, HashMap};
@@ -103,8 +106,16 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     /// assert_eq!(map.get(&"d"), None);
     /// assert_eq!(map.len(), 2);
     /// ```
+    #[cfg(feature = "raw-entry")]
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_entry_mut(&mut self) -> RawEntryBuilderMut<'_, K, V, S, A> {
+        RawEntryBuilderMut { map: self }
+    }
+
+    // FIXME: this is still used in the `HashSet` implementation
+    #[cfg(not(feature = "raw-entry"))]
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub(crate) fn raw_entry_mut(&mut self) -> RawEntryBuilderMut<'_, K, V, S, A> {
         RawEntryBuilderMut { map: self }
     }
 
@@ -153,6 +164,7 @@ impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     /// }
     /// ```
     #[cfg_attr(feature = "inline-more", inline)]
+    #[cfg(feature = "raw-entry")]
     pub fn raw_entry(&self) -> RawEntryBuilder<'_, K, V, S, A> {
         RawEntryBuilder { map: self }
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1599,10 +1599,10 @@ where
         for item in rhs {
             let entry = self.map.raw_entry_mut().from_key(item);
             match entry {
-                map::RawEntryMut::Occupied(e) => {
+                crate::raw_entry::RawEntryMut::Occupied(e) => {
                     e.remove();
                 }
-                map::RawEntryMut::Vacant(e) => {
+                crate::raw_entry::RawEntryMut::Vacant(e) => {
                     e.insert(item.to_owned(), ());
                 }
             };


### PR DESCRIPTION
`HashSet` still uses `raw_entry_mut()` internally, but now we can build
that without exposing it in the public API.
