### PR TITLE
Update changelog for v0.15.0, bump cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [v0.15.0] - 2024-09-??
+## [v0.15.0] - 2024-10-01
 
 This update contains breaking changes that remove the `raw` API with the hope of
 centralising on the `HashTable` API in the future. You can follow the discussion
@@ -31,9 +31,11 @@ that were previously only possible on the `raw` API.
 - Improved `HashSet::is_disjoint` performance. (#531)
 - `equivalent` feature is now enabled by default. (#532)
 - `HashSet` operators now return a set with the same allocator. (#529)
+- Changed the default hasher to foldhash. (#563)
 - `ahash` feature has been renamed to `default-hasher`. (#533)
 - Entry API has been reworked and several methods have been renamed. (#535)
 - `Hash{Map,Set}::insert_unique_unchecked` is now unsafe. (#556)
+- The signature of `get_many_mut` and related methods was changed. (#562)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [v0.15.0] - 2024-09-??
+
+This update contains breaking changes that remove the `raw` API with the hope of
+centralising on the `HashTable` API in the future. You can follow the discussion
+and progress in #545 to discuss features you think should be added to this API
+that were previously only possible on the `raw` API.
+
+### Added
+
+- Added `borsh` feature with `BorshSerialize` and `BorshDeserialize` impls. (#525)
+- Added `Assign` impls for `HashSet` operators. (#529)
+- Added `Default` impls for iterator types. (#542)
+- Added `HashTable::iter_hash{,_mut}` methods. (#549)
+- Added `Hash{Table,Map,Set}::allocation_size` methods. (#553)
+- Implemented `Debug` and `FusedIterator` for all `HashTable` iterators. (#561)
+- Specialized `Iterator::fold` for all `HashTable` iterators. (#561)
+
 ### Changed
 
-- Changed `hash_set::{Entry, VacantEntry}::insert` to return `OccupiedEntry`. (#495)
+- Changed `hash_set::VacantEntry::insert` to return `OccupiedEntry`. (#495)
+- Improved`hash_set::Difference::size_hint` lower-bound. (#530)
+- Improved `HashSet::is_disjoint` performance. (#531)
+- `equivalent` feature is now enabled by default. (#532)
+- `HashSet` operators now return a set with the same allocator. (#529)
+- `ahash` feature has been renamed to `default-hasher`. (#533)
+- Entry API has been reworked and several methods have been renamed. (#535)
+- `Hash{Map,Set}::insert_unique_unchecked` is now unsafe. (#556)
+
+### Fixed
+
+* Fixed typos, stray backticks in docs. (#558, #560)
+
+### Removed
+
+- Raw entry API is now under `raw-entry` feature, to be eventually removed. (#534, #555)
+- Raw table API has been made private and the `raw` feature is removed;
+  in the future, all code should be using the `HashTable` API instead. (#531, #546)
+- `rykv` feature was removed; this is now provided by the `rykv` crate instead. (#554)
+- `HashSet::get_or_insert_owned` was removed in favor of `get_or_insert_with`. (#555)
 
 ## [v0.14.5] - 2024-04-28
 
@@ -485,7 +521,8 @@ This release was _yanked_ due to a breaking change for users of `no-default-feat
 
 - Initial release
 
-[Unreleased]: https://github.com/rust-lang/hashbrown/compare/v0.14.5...HEAD
+[Unreleased]: https://github.com/rust-lang/hashbrown/compare/v0.15.0...HEAD
+[v0.15.0]: https://github.com/rust-lang/hashbrown/compare/v0.14.5...v0.15.0
 [v0.14.5]: https://github.com/rust-lang/hashbrown/compare/v0.14.4...v0.14.5
 [v0.14.4]: https://github.com/rust-lang/hashbrown/compare/v0.14.3...v0.14.4
 [v0.14.3]: https://github.com/rust-lang/hashbrown/compare/v0.14.2...v0.14.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "A Rust port of Google's SwissTable hash map"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This crate has the following Cargo features:
 - `serde`: Enables serde serialization support.
 - `borsh`: Enables borsh serialization support.
 - `rayon`: Enables rayon parallel iterator support.
-- `equivalent`: Allows comparisons to be customized with the `Equivalent` trait.
+- `equivalent`: Allows comparisons to be customized with the `Equivalent` trait. (enabled by default)
 - `raw-entry`: Enables access to the deprecated `RawEntry` API.
 - `inline-more`: Adds inline hints to most functions, improving run-time performance at the cost
   of compilation time. (enabled by default)


### PR DESCRIPTION
Rather than just asking @Amanieu to do all this, I decided to help out a bit. Put some question marks in the date field that will need to be replaced once this is actually merged.

Will still need someone to do a proper release for this, but hopefully the changelog is good at least.