### PR TITLE
Re-introduce a way to get the allocation size of a table

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1929,6 +1929,16 @@ where
         let hash = make_hash::<Q, S>(&self.hash_builder, k);
         self.table.remove_entry(hash, equivalent_key(k))
     }
+
+    /// Returns the total amount of memory allocated internally by the hash
+    /// set, in bytes.
+    ///
+    /// The returned number is informational only. It is intended to be
+    /// primarily used for memory profiling.
+    #[inline]
+    pub fn allocation_size(&self) -> usize {
+        self.table.allocation_size()
+    }
 }
 
 impl<K, V, S, A> PartialEq for HashMap<K, V, S, A>
@@ -6415,5 +6425,14 @@ mod test_map {
 
         // All allocator clones should already be dropped.
         assert_eq!(dropped.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn test_allocation_info() {
+        assert_eq!(HashMap::<(), ()>::new().allocation_size(), 0);
+        assert_eq!(HashMap::<u32, u32>::new().allocation_size(), 0);
+        assert!(
+            HashMap::<u32, u32>::with_capacity(1).allocation_size() > core::mem::size_of::<u32>()
+        );
     }
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1230,6 +1230,16 @@ where
             None => None,
         }
     }
+
+    /// Returns the total amount of memory allocated internally by the hash
+    /// set, in bytes.
+    ///
+    /// The returned number is informational only. It is intended to be
+    /// primarily used for memory profiling.
+    #[inline]
+    pub fn allocation_size(&self) -> usize {
+        self.map.allocation_size()
+    }
 }
 
 impl<T, S, A> PartialEq for HashSet<T, S, A>
@@ -3054,5 +3064,12 @@ mod test_set {
         // At the time of writing, this hits the ZST case in from_base_index
         // (and without the `map`, it does not).
         let mut _set: HashSet<_> = (0..3).map(|_| ()).collect();
+    }
+
+    #[test]
+    fn test_allocation_info() {
+        assert_eq!(HashSet::<()>::new().allocation_size(), 0);
+        assert_eq!(HashSet::<u32>::new().allocation_size(), 0);
+        assert!(HashSet::<u32>::with_capacity(1).allocation_size() > core::mem::size_of::<u32>());
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1088,6 +1088,16 @@ where
     ) -> Option<[&'_ mut T; N]> {
         self.raw.get_many_unchecked_mut(hashes, eq)
     }
+
+    /// Returns the total amount of memory allocated internally by the hash
+    /// table, in bytes.
+    ///
+    /// The returned number is informational only. It is intended to be
+    /// primarily used for memory profiling.
+    #[inline]
+    pub fn allocation_size(&self) -> usize {
+        self.raw.allocation_size()
+    }
 }
 
 impl<T, A> IntoIterator for HashTable<T, A>
@@ -2208,3 +2218,15 @@ where
 }
 
 impl<T, F, A: Allocator> FusedIterator for ExtractIf<'_, T, F, A> where F: FnMut(&mut T) -> bool {}
+
+#[cfg(test)]
+mod tests {
+    use super::HashTable;
+
+    #[test]
+    fn test_allocation_info() {
+        assert_eq!(HashTable::<()>::new().allocation_size(), 0);
+        assert_eq!(HashTable::<u32>::new().allocation_size(), 0);
+        assert!(HashTable::<u32>::with_capacity(1).allocation_size() > core::mem::size_of::<u32>());
+    }
+}


### PR DESCRIPTION
This was previously removed from `RawTable` in #546. This is now added as a public API on `HashMap`, `HashSet` and `HashTable`.

Fixes #238 
Fixes #506 