### PR TITLE
Wean `HashSet` from the raw-entry API

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -43,8 +43,8 @@ if [ "${CHANNEL}" = "nightly" ]; then
 fi
 
 # Make sure we can compile without the default hasher
-"${CARGO}" -vv build --target="${TARGET}" --no-default-features --features raw-entry
-"${CARGO}" -vv build --target="${TARGET}" --release --no-default-features --features raw-entry
+"${CARGO}" -vv build --target="${TARGET}" --no-default-features
+"${CARGO}" -vv build --target="${TARGET}" --release --no-default-features
 
 "${CARGO}" -vv ${OP} --target="${TARGET}"
 "${CARGO}" -vv ${OP} --target="${TARGET}" --features "${FEATURES}"


### PR DESCRIPTION
This changes `get_or_insert`, `get_or_insert_with`, and `bitxor_assign`
to poke directly at the `RawTable` instead of using `raw_entry_mut()`.

`HashSet::get_or_insert_with` also asserts that the converted value is
actually equivalent after conversion, so we can ensure set consistency.
`HashSet::get_or_insert_owned` is removed for now, since it offers no
value over the `_with` method, as we would need to assert that too.
