### PR TITLE
Make `insert_unique_unchecked` unsafe

### DIFF
--- a/benches/insert_unique_unchecked.rs
+++ b/benches/insert_unique_unchecked.rs
@@ -25,7 +25,9 @@ fn insert_unique_unchecked(b: &mut Bencher) {
     b.iter(|| {
         let mut m = HashMap::with_capacity(1000);
         for k in &keys {
-            m.insert_unique_unchecked(k, k);
+            unsafe {
+                m.insert_unique_unchecked(k, k);
+            }
         }
         m
     });

--- a/src/map.rs
+++ b/src/map.rs
@@ -1783,7 +1783,7 @@ where
     ///
     /// However this operation is still unsafe because the resulting `HashMap`
     /// may be passed to unsafe code which does expect the map to behave
-    /// correctly, and would could unsoundness as a result.
+    /// correctly, and would cause unsoundness as a result.
     ///
     /// # Examples
     ///

--- a/src/set.rs
+++ b/src/set.rs
@@ -1118,25 +1118,29 @@ where
 
     /// Insert a value the set without checking if the value already exists in the set.
     ///
-    /// Returns a reference to the value just inserted.
-    ///
-    /// This operation is safe if a value does not exist in the set.
-    ///
-    /// However, if a value exists in the set already, the behavior is unspecified:
-    /// this operation may panic, loop forever, or any following operation with the set
-    /// may panic, loop forever or return arbitrary result.
-    ///
-    /// That said, this operation (and following operations) are guaranteed to
-    /// not violate memory safety.
-    ///
     /// This operation is faster than regular insert, because it does not perform
     /// lookup before insertion.
     ///
     /// This operation is useful during initial population of the set.
     /// For example, when constructing a set from another set, we know
     /// that values are unique.
+    ///
+    /// # Safety
+    ///
+    /// This operation is safe if a key does not exist in the set.
+    ///
+    /// However, if a key exists in the set already, the behavior is unspecified:
+    /// this operation may panic, loop forever, or any following operation with the set
+    /// may panic, loop forever or return arbitrary result.
+    ///
+    /// That said, this operation (and following operations) are guaranteed to
+    /// not violate memory safety.
+    ///
+    /// However this operation is still unsafe because the resulting `HashSet`
+    /// may be passed to unsafe code which does expect the set to behave
+    /// correctly, and would could unsoundness as a result.
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn insert_unique_unchecked(&mut self, value: T) -> &T {
+    pub unsafe fn insert_unique_unchecked(&mut self, value: T) -> &T {
         self.map.insert_unique_unchecked(value, ()).0
     }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1127,9 +1127,9 @@ where
     ///
     /// # Safety
     ///
-    /// This operation is safe if a key does not exist in the set.
+    /// This operation is safe if a value does not exist in the set.
     ///
-    /// However, if a key exists in the set already, the behavior is unspecified:
+    /// However, if a value exists in the set already, the behavior is unspecified:
     /// this operation may panic, loop forever, or any following operation with the set
     /// may panic, loop forever or return arbitrary result.
     ///
@@ -1138,7 +1138,7 @@ where
     ///
     /// However this operation is still unsafe because the resulting `HashSet`
     /// may be passed to unsafe code which does expect the set to behave
-    /// correctly, and would could unsoundness as a result.
+    /// correctly, and would cause unsoundness as a result.
     #[cfg_attr(feature = "inline-more", inline)]
     pub unsafe fn insert_unique_unchecked(&mut self, value: T) -> &T {
         self.map.insert_unique_unchecked(value, ()).0


### PR DESCRIPTION
This is in line with the standard library guarantees that it should be impossible to create an inconsistent `HashMap` with well-defined key types.