### PR TITLE
ci: test the MSRV with minimal dependency versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,18 @@ jobs:
           target: x86_64-unknown-linux-gnu
           channel: stable
 
+  msrv:
+    runs-on: ubuntu-latest
+    needs: basics
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@nightly
+    - uses: dtolnay/rust-toolchain@1.65.0 # MSRV
+    - run: cargo +nightly generate-lockfile -Z direct-minimal-versions
+    - env:
+        TARGET: x86_64-unknown-linux-gnu
+      run: sh ci/run.sh
+
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a
   # workflow is successful listening to webhooks only.
@@ -88,7 +100,7 @@ jobs:
     name: bors build finished
     if: github.event.pusher.name == 'bors' && success()
     runs-on: ubuntu-latest
-    needs: [miri, rustfmt_clippy, test]
+    needs: [miri, rustfmt_clippy, test, msrv]
 
     steps:
       - name: Mark the job as successful
@@ -98,7 +110,7 @@ jobs:
     name: bors build finished
     if: github.event.pusher.name == 'bors' && (failure() || cancelled())
     runs-on: ubuntu-latest
-    needs: [miri, rustfmt_clippy, test]
+    needs: [miri, rustfmt_clippy, test, msrv]
 
     steps:
       - name: Mark the job as a failure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65.0"
 foldhash = { version = "0.1.2", default-features = false, optional = true }
 
 # For external trait impls
-rayon = { version = "1.0", optional = true }
+rayon = { version = "1.2", optional = true }
 serde = { version = "1.0.25", default-features = false, optional = true }
 borsh = { version = "1.5.0", default-features = false, optional = true, features = ["derive"]}
 
@@ -37,7 +37,7 @@ equivalent = { version = "1.0", optional = true, default-features = false }
 [dev-dependencies]
 lazy_static = "1.4"
 rand = { version = "0.8.3", features = ["small_rng"] }
-rayon = "1.0"
+rayon = "1.2"
 fnv = "1.0.7"
 serde_test = "1.0"
 doc-comment = "0.3.1"

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -105,7 +105,7 @@ impl<T> SizedTypeProperties for T {}
 /// Single tag in a control group.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 #[repr(transparent)]
-struct Tag(u8);
+pub(crate) struct Tag(u8);
 impl Tag {
     /// Control tag value for an empty bucket.
     const EMPTY: Tag = Tag(0b1111_1111);


### PR DESCRIPTION
This includes a slight bump of rayon for use of `ParallelIterator::copied`, and `pub(crate)` on `raw::Tag` because older compilers complain about the `pub(crate)` methods that expose it.