### PR TITLE
Switch from using Bors to merge queue in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,11 +1,8 @@
 name: Rust
 
 on:
-  push:
-    branches-ignore:
-      - trying.tmp
-      - staging.tmp
   pull_request:
+  merge_group:
 
 jobs:
   miri:
@@ -90,28 +87,14 @@ jobs:
         TARGET: x86_64-unknown-linux-gnu
       run: sh ci/run.sh
 
-  # These jobs doesn't actually test anything, but they're only used to tell
-  # bors the build completed, as there is no practical way to detect when a
-  # workflow is successful listening to webhooks only.
-  #
-  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
-
-  end-success:
-    name: bors build finished
-    if: github.event.pusher.name == 'bors' && success()
+  conclusion:
+    needs: [test, msrv]
+    # !cancelled() executes the job regardless of whether the previous jobs passed, failed or get skipped.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    needs: [miri, rustfmt_clippy, test, msrv]
-
     steps:
-      - name: Mark the job as successful
-        run: exit 0
-
-  end-failure:
-    name: bors build finished
-    if: github.event.pusher.name == 'bors' && (failure() || cancelled())
-    runs-on: ubuntu-latest
-    needs: [miri, rustfmt_clippy, test, msrv]
-
-    steps:
-      - name: Mark the job as a failure
-        run: exit 1
+      - name: Conclusion
+        run: |
+          jq -C <<< '${{ toJson(needs) }}'
+          # Check if all needs were successful.
+          jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'


### PR DESCRIPTION
Part of ongoing effort of reducing the amount of repos managed by homu (https://github.com/rust-lang/infra-team/issues/169).

I left the conclusion jobs at the end, because they run a large job matrix, so it would be annoying to enumerate all these jobs in the CI config. Instead, I added `conclusion` as a required CI check for the `master` branch in https://github.com/rust-lang/team/pull/1577.