### PR TITLE
add back strict provenance lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
         allocator_api,
         slice_ptr_get,
         maybe_uninit_array_assume_init,
+        strict_provenance_lints
     )
 )]
 #![allow(
@@ -35,6 +36,7 @@
 )]
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
+#![cfg_attr(feature = "nightly", warn(fuzzy_provenance_casts))]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
 
 /// Default hasher for [`HashMap`] and [`HashSet`].


### PR DESCRIPTION
The lint got removed in https://github.com/rust-lang/hashbrown/pull/582, but it still exists unstably, so -- IMO it makes sense to add it back.