### PR TITLE
Double the width of static allocations for empty tables

### DIFF
--- a/src/control/group/generic.rs
+++ b/src/control/group/generic.rs
@@ -50,20 +50,23 @@ impl Group {
     /// Number of bytes in the group.
     pub(crate) const WIDTH: usize = mem::size_of::<Self>();
 
+    /// Double the group width; size of [`Group::static_empty`].
+    pub(crate) const DOUBLE_WIDTH: usize = Group::WIDTH * 2;
+
     /// Returns a full group of empty tags, suitable for use as the initial
     /// value for an empty hash table.
     ///
     /// This is guaranteed to be aligned to the group size.
     #[inline]
-    pub(crate) const fn static_empty() -> &'static [Tag; Group::WIDTH] {
+    pub(crate) const fn static_empty() -> &'static [Tag; Group::DOUBLE_WIDTH] {
         #[repr(C)]
         struct AlignedTags {
             _align: [Group; 0],
-            tags: [Tag; Group::WIDTH],
+            tags: [Tag; Group::DOUBLE_WIDTH],
         }
         const ALIGNED_TAGS: AlignedTags = AlignedTags {
             _align: [],
-            tags: [Tag::EMPTY; Group::WIDTH],
+            tags: [Tag::EMPTY; Group::DOUBLE_WIDTH],
         };
         &ALIGNED_TAGS.tags
     }

--- a/src/control/group/neon.rs
+++ b/src/control/group/neon.rs
@@ -21,20 +21,23 @@ impl Group {
     /// Number of bytes in the group.
     pub(crate) const WIDTH: usize = mem::size_of::<Self>();
 
+    /// Double the group width; size of [`Group::static_empty`].
+    pub(crate) const DOUBLE_WIDTH: usize = Group::WIDTH * 2;
+
     /// Returns a full group of empty tags, suitable for use as the initial
     /// value for an empty hash table.
     ///
     /// This is guaranteed to be aligned to the group size.
     #[inline]
-    pub(crate) const fn static_empty() -> &'static [Tag; Group::WIDTH] {
+    pub(crate) const fn static_empty() -> &'static [Tag; Group::DOUBLE_WIDTH] {
         #[repr(C)]
         struct AlignedTags {
             _align: [Group; 0],
-            tags: [Tag; Group::WIDTH],
+            tags: [Tag; Group::DOUBLE_WIDTH],
         }
         const ALIGNED_TAGS: AlignedTags = AlignedTags {
             _align: [],
-            tags: [Tag::EMPTY; Group::WIDTH],
+            tags: [Tag::EMPTY; Group::DOUBLE_WIDTH],
         };
         &ALIGNED_TAGS.tags
     }

--- a/src/control/group/sse2.rs
+++ b/src/control/group/sse2.rs
@@ -26,21 +26,24 @@ impl Group {
     /// Number of bytes in the group.
     pub(crate) const WIDTH: usize = mem::size_of::<Self>();
 
+    /// Double the group width; size of [`Group::static_empty`].
+    pub(crate) const DOUBLE_WIDTH: usize = Group::WIDTH * 2;
+
     /// Returns a full group of empty tags, suitable for use as the initial
     /// value for an empty hash table.
     ///
     /// This is guaranteed to be aligned to the group size.
     #[inline]
     #[allow(clippy::items_after_statements)]
-    pub(crate) const fn static_empty() -> &'static [Tag; Group::WIDTH] {
+    pub(crate) const fn static_empty() -> &'static [Tag; Group::DOUBLE_WIDTH] {
         #[repr(C)]
         struct AlignedTags {
             _align: [Group; 0],
-            tags: [Tag; Group::WIDTH],
+            tags: [Tag; Group::DOUBLE_WIDTH],
         }
         const ALIGNED_TAGS: AlignedTags = AlignedTags {
             _align: [],
-            tags: [Tag::EMPTY; Group::WIDTH],
+            tags: [Tag::EMPTY; Group::DOUBLE_WIDTH],
         };
         &ALIGNED_TAGS.tags
     }


### PR DESCRIPTION
See this discussion here: https://github.com/rust-lang/hashbrown/pull/578#discussion_r1800275708

Effectively, the current code will actually need `Group::WIDTH + 1` bytes for an empty table, but we only allocate `Group::WIDTH` bytes for it. This could potentially invoke UB based upon the invariants we set in the table, but because we happen to short-circuit empty tables in just the right ways in the actual code, we never actually trigger it.

Since the static allocations are aligned to the group width, we double the size returned, since it would otherwise just add that much extra padding anyway. And since the size of the static allocations added by this is effectively insignificant (8-16 bytes depending on the implementation chosen), it's fair to just do this anyway to make the code more robust.