### PR TITLE
Fix clippy lints

### DIFF
--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -186,7 +186,7 @@ mod set {
             where
                 A: Allocator;
 
-            impl<'a, 'de, T, S, A> Visitor<'de> for SeqInPlaceVisitor<'a, T, S, A>
+            impl<'de, T, S, A> Visitor<'de> for SeqInPlaceVisitor<'_, T, S, A>
             where
                 T: Deserialize<'de> + Eq + Hash,
                 S: BuildHasher + Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,10 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 #![cfg_attr(feature = "nightly", warn(fuzzy_provenance_casts))]
-#![cfg_attr(feature = "nightly", allow(internal_features))]
+#![cfg_attr(
+    feature = "nightly",
+    allow(clippy::incompatible_msrv, internal_features)
+)]
 
 /// Default hasher for [`HashMap`] and [`HashSet`].
 #[cfg(feature = "default-hasher")]


### PR DESCRIPTION
Since CI is using nightly clippy, newly added lints are failing on CI.