### PR TITLE
Add immutable map accessors to OccupiedEntry and VacantEntry

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -4028,11 +4028,11 @@ impl<'a, K, V, S, A: Allocator> OccupiedEntry<'a, K, V, S, A> {
     /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
     ///
     /// match map.entry("abc") {
-    ///   Entry::Occupied(mut e) => if some_expensive_operation(e.map().get("def")) { e.insert(5); },
+    ///   Entry::Occupied(mut e) => if some_expensive_operation(e.hash_map().get("def")) { e.insert(5); },
     ///   Entry::Vacant(_) => {}
     /// }
     /// ```
-    pub fn map(&self) -> &HashMap<K, V, S, A> {
+    pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
         self.table
     }
 }
@@ -4154,11 +4154,11 @@ impl<'a, K, V, S, A: Allocator> VacantEntry<'a, K, V, S, A> {
     /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
     ///
     /// match map.entry("abc") {
-    ///   Entry::Vacant(mut e) => if some_expensive_operation(e.map().get("def")) { e.insert(5); },
+    ///   Entry::Vacant(e) => if some_expensive_operation(e.hash_map().get("def")) { e.insert(5); },
     ///   Entry::Occupied(_) => {}
     /// }
     /// ```
-    pub fn map(&self) -> &HashMap<K, V, S, A> {
+    pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
         self.table
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3714,6 +3714,33 @@ impl<'a, K, V, S, A: Allocator> Entry<'a, K, V, S, A> {
             Entry::Vacant(_) => self,
         }
     }
+
+    /// Gets a reference to the map that owns this entry.
+    ///
+    /// This can be used to perform additional lookups while deciding
+    /// how to process the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::Entry;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
+    ///
+    /// let e = map.entry("abc");
+    /// if some_expensive_operation(e.hash_map().get("def")) {
+    ///   e.insert(5);
+    /// }
+    /// ```
+    pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
+        match *self {
+            Entry::Occupied(ref entry) => entry.hash_map(),
+            Entry::Vacant(ref entry) => entry.hash_map(),
+        }
+    }
 }
 
 impl<'a, K, V: Default, S, A: Allocator> Entry<'a, K, V, S, A> {
@@ -4027,9 +4054,10 @@ impl<'a, K, V, S, A: Allocator> OccupiedEntry<'a, K, V, S, A> {
     ///
     /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
     ///
-    /// match map.entry("abc") {
-    ///   Entry::Occupied(mut e) => if some_expensive_operation(e.hash_map().get("def")) { e.insert(5); },
-    ///   Entry::Vacant(_) => {}
+    /// if let Entry::Occupied(mut e) = map.entry("abc") {
+    ///   if some_expensive_operation(e.hash_map().get("def")) {
+    ///     e.insert(5);
+    ///  }
     /// }
     /// ```
     pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
@@ -4153,9 +4181,10 @@ impl<'a, K, V, S, A: Allocator> VacantEntry<'a, K, V, S, A> {
     ///
     /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
     ///
-    /// match map.entry("abc") {
-    ///   Entry::Vacant(e) => if some_expensive_operation(e.hash_map().get("def")) { e.insert(5); },
-    ///   Entry::Occupied(_) => {}
+    /// if let Entry::Vacant(e) = map.entry("abc") {
+    ///   if some_expensive_operation(e.hash_map().get("def")) {
+    ///     e.insert(5);
+    ///   }
     /// }
     /// ```
     pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
@@ -4343,6 +4372,33 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator> EntryRef<'a, 'b, K, Q, V, S, A> {
             EntryRef::Vacant(entry) => EntryRef::Vacant(entry),
         }
     }
+
+    /// Gets a reference to the map that owns this entry.
+    ///
+    /// This can be used to perform additional lookups while deciding
+    /// how to process the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::EntryRef;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
+    ///
+    /// let e = map.entry_ref("abc");
+    /// if some_expensive_operation(e.hash_map().get("def")) {
+    ///   e.insert(5);
+    /// }
+    /// ```
+    pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
+        match *self {
+            EntryRef::Occupied(ref entry) => entry.hash_map(),
+            EntryRef::Vacant(ref entry) => entry.hash_map(),
+        }
+    }
 }
 
 impl<'a, 'b, K, Q: ?Sized, V: Default, S, A: Allocator> EntryRef<'a, 'b, K, Q, V, S, A> {
@@ -4460,6 +4516,31 @@ impl<'a, 'b, K, Q: ?Sized, V, S, A: Allocator> VacantEntryRef<'a, 'b, K, Q, V, S
             elem,
             table: self.table,
         }
+    }
+
+    /// Gets a reference to the map that owns this entry.
+    ///
+    /// This can be used to perform additional lookups while deciding
+    /// how to process the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::EntryRef;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
+    ///
+    /// if let EntryRef::Vacant(e) = map.entry_ref("abc") {
+    ///   if some_expensive_operation(e.hash_map().get("def")) {
+    ///     e.insert(5);
+    ///   }
+    /// }
+    /// ```
+    pub fn hash_map(&self) -> &HashMap<K, V, S, A> {
+        self.table
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -4011,6 +4011,30 @@ impl<'a, K, V, S, A: Allocator> OccupiedEntry<'a, K, V, S, A> {
             }
         }
     }
+
+    /// Gets a reference to the map that owns this entry.
+    ///
+    /// This can be used to perform additional lookups while deciding
+    /// how to process the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::Entry;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
+    ///
+    /// match map.entry("abc") {
+    ///   Entry::Occupied(mut e) => if some_expensive_operation(e.map().get("def")) { e.insert(5); },
+    ///   Entry::Vacant(_) => {}
+    /// }
+    /// ```
+    pub fn map(&self) -> &HashMap<K, V, S, A> {
+        self.table
+    }
 }
 
 impl<'a, K, V, S, A: Allocator> VacantEntry<'a, K, V, S, A> {
@@ -4112,6 +4136,30 @@ impl<'a, K, V, S, A: Allocator> VacantEntry<'a, K, V, S, A> {
             elem,
             table: self.table,
         }
+    }
+
+    /// Gets a reference to the map that owns this entry.
+    ///
+    /// This can be used to perform additional lookups while deciding
+    /// how to process the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashbrown::HashMap;
+    /// use hashbrown::hash_map::Entry;
+    ///
+    /// let mut map: HashMap<&str, u32> = HashMap::new();
+    ///
+    /// fn some_expensive_operation(val: Option<&u32>) -> bool { true }
+    ///
+    /// match map.entry("abc") {
+    ///   Entry::Vacant(mut e) => if some_expensive_operation(e.map().get("def")) { e.insert(5); },
+    ///   Entry::Occupied(_) => {}
+    /// }
+    /// ```
+    pub fn map(&self) -> &HashMap<K, V, S, A> {
+        self.table
     }
 }
 


### PR DESCRIPTION
Without these, it is not possible to inspect other keys in the map while deciding how to process the entry, forcing the user to either perform unnecessary work before calling entry or performing multiple map lookups for the entry key.

For example:

```rust
fn some_expensive_operation(...) -> bool { ... }

let mut map: HashMap<K, V> = ...;

// old way, with two lookups for `key`
if !map.contains_key(key) && some_expensive_operation(map.get(other_key)) {
    map.insert(key, val);
}

// old way, with expensive operation done unnecessarily when `key` is
// already present
if some_expensive_operation(map.get(other_key)) {
    if let VacantEntry(e) = map.entry(key) {
        e.insert(val);
    }
}

// new way, with one lookup for `key`
if let VacantEntry(e) = map.entry(key) {
  if some_expensive_operation(e.map().get(other_key)) {
    e.insert(val);
  }
}
```

We do not provide accessors returning a mutable reference to the map because doing so would make it possible to invalidate the entry itself.