### PR TITLE
HashMap: #or_default_entry and #or_insert_entry

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -6229,7 +6229,7 @@ mod test_map {
             }
 
             for (k, v) in map {
-                println!("{}, {}", k, v);
+                println!("{k}, {v}");
             }
         }
 
@@ -6334,8 +6334,7 @@ mod test_map {
             for ((key, value), (panic_in_clone, panic_in_drop)) in guard.iter().zip(iter) {
                 if *key != check_count {
                     return Err(format!(
-                        "key != check_count,\nkey: `{}`,\ncheck_count: `{}`",
-                        key, check_count
+                        "key != check_count,\nkey: `{key}`,\ncheck_count: `{check_count}`"
                     ));
                 }
                 if value.dropped
@@ -6362,8 +6361,7 @@ mod test_map {
 
             if count != check_count {
                 return Err(format!(
-                    "count != check_count,\ncount: `{}`,\ncheck_count: `{}`",
-                    count, check_count
+                    "count != check_count,\ncount: `{count}`,\ncheck_count: `{check_count}`"
                 ));
             }
             core::mem::forget(guard);


### PR DESCRIPTION
I often find myself in a situation where I would like to insert a key into a map via `#entry_ref` and then use the key from the resulting entry.

```rust
// Get a byte slice from a buffer
let key = client.request.get(index);

// Insert the value (default)
let mut entry = match queues.entry_ref(&key) {
    EntryRef::Occupied(entry) => entry,
    EntryRef::Vacant(entry) => entry.insert_entry(Default::default()),
};

// Use the value
entry.get_mut().insert_back(client.id);

// Reuse the key instead of copying the bytes again
keys.insert(client.id, entry.key());
```

This is common enough that I'd love to have functions for it, similar to `insert_entry`.

```rust
// Get a byte slice from a buffer
let key = client.request.get(index);

// Insert the value (default)
let mut entry = queues.entry_ref(&key).or_default_entry();

// Use the value
entry.get_mut().insert_back(client.id);

// Reuse the key instead of copying the bytes again
keys.insert(client.id, entry.key());
```