### PR TITLE
Don't enable `allocator-api2/nightly` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default = ["default-hasher", "inline-more", "allocator-api2", "equivalent", "raw
 
 # Enables use of nightly features. This is only guaranteed to work on the latest
 # version of nightly Rust.
-nightly = ["allocator-api2?/nightly", "bumpalo/allocator_api"]
+nightly = ["bumpalo/allocator_api"]
 
 # Enables the RustcEntry API used to provide the standard library's Entry API.
 rustc-internal-api = []

--- a/src/map.rs
+++ b/src/map.rs
@@ -4690,9 +4690,9 @@ mod test_map {
     use super::Entry::{Occupied, Vacant};
     use super::EntryRef;
     use super::HashMap;
+    use crate::raw::{AllocError, Allocator, Global};
     use alloc::string::{String, ToString};
     use alloc::sync::Arc;
-    use allocator_api2::alloc::{AllocError, Allocator, Global};
     use core::alloc::Layout;
     use core::ptr::NonNull;
     use core::sync::atomic::{AtomicI8, Ordering};

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+pub(crate) use self::inner::AllocError;
 pub(crate) use self::inner::{do_alloc, Allocator, Global};
 
 // Nightly-case.
@@ -6,6 +8,8 @@ pub(crate) use self::inner::{do_alloc, Allocator, Global};
 // This is used when building for `std`.
 #[cfg(feature = "nightly")]
 mod inner {
+    #[cfg(test)]
+    pub use crate::alloc::alloc::AllocError;
     use crate::alloc::alloc::Layout;
     pub use crate::alloc::alloc::{Allocator, Global};
     use core::ptr::NonNull;
@@ -28,6 +32,8 @@ mod inner {
 #[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
 mod inner {
     use crate::alloc::alloc::Layout;
+    #[cfg(test)]
+    pub use allocator_api2::alloc::AllocError;
     pub use allocator_api2::alloc::{Allocator, Global};
     use core::ptr::NonNull;
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -12,6 +12,8 @@ use core::slice;
 use core::{hint, ptr};
 
 mod alloc;
+#[cfg(test)]
+pub(crate) use self::alloc::AllocError;
 pub(crate) use self::alloc::{do_alloc, Allocator, Global};
 
 #[inline]
@@ -4238,9 +4240,9 @@ mod test_map {
     /// ARE ZERO, EVEN IF WE HAVE `FULL` CONTROL BYTES.
     #[test]
     fn test_catch_panic_clone_from() {
+        use super::{AllocError, Allocator, Global};
         use ::alloc::sync::Arc;
         use ::alloc::vec::Vec;
-        use allocator_api2::alloc::{AllocError, Allocator, Global};
         use core::sync::atomic::{AtomicI8, Ordering};
         use std::thread;
 


### PR DESCRIPTION
See #564 for rationale. Tentatively fixes said issue and #483, though the root cause is up to the `allocator-api2` crate to fix.

Direct use of `allocator-api2` in tests had to be replaced with the indirection used elsewhere in the crate.