### PR TITLE
Drop FnMut trait bounds from ExtractIf data structures

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -2596,10 +2596,7 @@ impl<K, V, A: Allocator> Drain<'_, K, V, A> {
 /// assert_eq!(map.len(), 1);
 /// ```
 #[must_use = "Iterators are lazy unless consumed"]
-pub struct ExtractIf<'a, K, V, F, A: Allocator = Global>
-where
-    F: FnMut(&K, &mut V) -> bool,
-{
+pub struct ExtractIf<'a, K, V, F, A: Allocator = Global> {
     f: F,
     inner: RawExtractIf<'a, (K, V), A>,
 }

--- a/src/set.rs
+++ b/src/set.rs
@@ -1678,10 +1678,7 @@ pub struct Drain<'a, K, A: Allocator = Global> {
 /// [`extract_if`]: struct.HashSet.html#method.extract_if
 /// [`HashSet`]: struct.HashSet.html
 #[must_use = "Iterators are lazy unless consumed"]
-pub struct ExtractIf<'a, K, F, A: Allocator = Global>
-where
-    F: FnMut(&K) -> bool,
-{
+pub struct ExtractIf<'a, K, F, A: Allocator = Global> {
     f: F,
     inner: RawExtractIf<'a, (K, ()), A>,
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -2343,10 +2343,7 @@ impl<T: fmt::Debug, A: Allocator> fmt::Debug for Drain<'_, T, A> {
 /// This `struct` is created by [`HashTable::extract_if`]. See its
 /// documentation for more.
 #[must_use = "Iterators are lazy unless consumed"]
-pub struct ExtractIf<'a, T, F, A: Allocator = Global>
-where
-    F: FnMut(&mut T) -> bool,
-{
+pub struct ExtractIf<'a, T, F, A: Allocator = Global> {
     f: F,
     inner: RawExtractIf<'a, T, A>,
 }


### PR DESCRIPTION
This is going to be required for resolving https://github.com/rust-lang/rust/issues/137654.

Of the 4 distinct signatures shown in that issue, the one we'd like to standardize on is the one currently being used by `alloc::collections::linked_list::ExtractIf`, which is _no_ `F: Debug` bound, _no_ `F: FnMut` bound, only `T: Debug` bound.

Without this change in hashbrown, the desired Debug impls in std for `std::collections::hash_map::ExtractIf` and `std::collections::hash_set::ExtractIf` fail to compile.

```console
error[E0277]: expected a `FnMut(&K, &mut V)` closure, found `F`
    --> library/std/src/collections/hash/map.rs:1683:11
     |
1683 |     base: base::ExtractIf<'a, K, V, F>,
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an `FnMut(&K, &mut V)` closure, found `F`
     |
note: required by a bound in `hashbrown::hash_map::ExtractIf`
    --> hashbrown/src/map.rs:2601:8
     |
2599 | pub struct ExtractIf<'a, K, V, F, A: Allocator = Global>
     |            --------- required by a bound in this struct
2600 | where
2601 |     F: FnMut(&K, &mut V) -> bool,
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ExtractIf`
help: consider restricting type parameter `F` with trait `FnMut`
     |
1682 | pub struct ExtractIf<'a, K, V, F: for<'a, 'b> FnMut(&'a K, &'b mut V)> {
     |                                 +++++++++++++++++++++++++++++++++++++
```