### PR TITLE
Remove "raw-entry" from "rustc-dep-of-std"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ rustc-dep-of-std = [
     "compiler_builtins",
     "alloc",
     "rustc-internal-api",
-    "raw-entry",
 ]
 
 # Enables the deprecated RawEntry API.


### PR DESCRIPTION
We stopped using this in https://github.com/rust-lang/rust/pull/138425.