### PR TITLE
feat: `HashTable::try_insert_unique_within_capacity`

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -707,6 +707,47 @@ where
         }
     }
 
+    /// Inserts an element into the `HashTable` with the given hash value, but
+    /// without checking whether an equivalent element already exists within
+    /// the table. If there is insufficient capacity, then this returns an
+    /// error holding the provided value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "nightly")]
+    /// # fn test() {
+    /// use hashbrown::{HashTable, DefaultHashBuilder};
+    /// use std::hash::BuildHasher;
+    ///
+    /// let mut v = HashTable::new();
+    /// let hasher = DefaultHashBuilder::default();
+    /// let hasher = |val: &_| hasher.hash_one(val);
+    /// assert!(v.try_insert_unique_within_capacity(hasher(&1), 1).is_err());
+    /// assert!(v.is_empty());
+    /// v.reserve(1, hasher);
+    /// assert!(v.try_insert_unique_within_capacity(hasher(&1), 1).is_ok());
+    /// assert!(!v.is_empty());
+    /// # }
+    /// # fn main() {
+    /// #     #[cfg(feature = "nightly")]
+    /// #     test()
+    /// # }
+    /// ```
+    pub fn try_insert_unique_within_capacity(
+        &mut self,
+        hash: u64,
+        value: T,
+    ) -> Result<OccupiedEntry<'_, T, A>, T> {
+        match self.raw.try_insert_within_capacity(hash, value) {
+            Ok(bucket) => Ok(OccupiedEntry {
+                bucket,
+                table: self,
+            }),
+            Err(value) => Err(value),
+        }
+    }
+
     /// Clears the table, removing all values.
     ///
     /// # Examples

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,12 @@
-// FIXME: Replace with `core::hint::{likely, unlikely}` once they are stable.
+// FIXME: Replace with `core::hint::{likely, unlikely, cold_path}` once they are stable.
 #[cfg(feature = "nightly")]
 pub(crate) use core::intrinsics::{likely, unlikely};
 
-#[cfg(not(feature = "nightly"))]
+/// Hints to the compiler that the code path calling this function is cold
+/// (unlikely to be executed).
 #[inline(always)]
 #[cold]
-fn cold_path() {}
+pub(crate) fn cold_path() {}
 
 #[cfg(not(feature = "nightly"))]
 #[inline(always)]


### PR DESCRIPTION
This implements #618 with this signature:

```rs
    pub fn try_insert_unique_within_capacity(
        &mut self,
        hash: u64,
        value: T,
    ) -> Result<OccupiedEntry<'_, T, A>, T>
```

This is safe-version from issue feedback, rather than the originally proposed unsafe version.

My personal motivation is to avoid panics. With `HashTable::insert_unique`, it calls `RawTable::insert` which calls `self.reserve(1, hasher)`, which will panic out of necessity if allocation fails.

Today, you can call `HashTable::try_reserve` before calling `HashTable::insert_unique` to avoid the panic in practice. However, this is not compatible with techniques like using `no-panic` to detect at compile/link time that a function does not panic. I have verified with this patch that it's `no_panic::no_panic` compatible. This is not public yet, so I can't share the source for you to verify it yourself, but it's nothing too interesting.

This also has an impact on code size. I don't have concrete, trustworthy numbers for this. The compiler does not optimize away the memory growth path in `insert_unique` after a `try_reserve`, so it's easy to see that it should get smaller, it's just a matter of how much.