### PR TITLE
Add missing test for set

### DIFF
--- a/src/set.rs
+++ b/src/set.rs
@@ -3102,4 +3102,20 @@ mod test_set {
             set.get_or_insert_with(&key, |_| value);
         }
     }
+
+    #[test]
+    fn test_sub_assign() {
+        let mut a: HashSet<_> = vec![1, 2, 3, 4].into_iter().collect();
+        let b: HashSet<_> = vec![3, 5].into_iter().collect();
+
+        a -= &b;
+
+        let mut i = 0;
+        let expected = [1, 2, 4];
+        for x in &a {
+            assert!(expected.contains(x));
+            i += 1;
+        }
+        assert_eq!(i, expected.len());
+    }
 }


### PR DESCRIPTION
Hi,

Thanks for your time to review this PR.

We are researchers focusing on generating Rust tests by LLM to statisfy specific execution paths in functions. By examing the existing code, we found that one test can be added to improve the repo's overall test coverage.
The code region we covered is:
https://github.com/rust-lang/hashbrown/blob/62634581de016626f31e1d993b504fe7db1b39f1/src/set.rs#L1630-L1633

The current doc test only covers rhs.len() >= self.len(). To keep documentation example concise, we add a unit test for the rhs.len() < self.len() case.

Thanks again for reviewing.