### PR TITLE
Add test for HashMap::get_mut with non-existent key

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -5058,6 +5058,10 @@ mod test_map {
             Some(x) => *x = new,
         }
         assert_eq!(m.get(&5), Some(&new));
+        let mut hashmap: HashMap<i32, String> = HashMap::default();
+        let key = &1;
+        let result = hashmap.get_mut(key);
+        assert!(result.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Hi team,

This pull request adds a test aimed at improving the test coverage within the repository.

The primary focus of these tests is on the HashMap::get_mut. We've ensured these tests are robust and cover key scenarios.

map.rs

https://github.com/rust-lang/hashbrown/blob/62634581de016626f31e1d993b504fe7db1b39f1/src/map.rs#L1452

https://github.com/rust-lang/hashbrown/blob/62634581de016626f31e1d993b504fe7db1b39f1/src/map.rs#L1462

raw/mod.rs

https://github.com/rust-lang/hashbrown/blob/62634581de016626f31e1d993b504fe7db1b39f1/src/raw/mod.rs#L1868

We appreciate your time in reviewing these additions.

Thanks.