### PR TITLE
Remove optional dependency on compiler-builtins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0.25", default-features = false, optional = true }
 
 # When built as part of libstd
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-compiler_builtins = { version = "0.1.2", optional = true }
 alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
 # Support for allocators that use allocator-api2
@@ -56,7 +55,6 @@ rustc-internal-api = []
 rustc-dep-of-std = [
     "nightly",
     "core",
-    "compiler_builtins",
     "alloc",
     "rustc-internal-api",
 ]


### PR DESCRIPTION
Since `hashbrown` always has `extern crate alloc`, it will get `compiler-builtins` via `alloc`'s dependency. There is no longer any need to depend on the crates.io version.