### PR TITLE
Re-implement likely/unlikely with `#[cold]`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,33 @@
-// FIXME: Branch prediction hint. This is currently only available on nightly
-// but it consistently improves performance by 10-15%.
-#[cfg(not(feature = "nightly"))]
-pub(crate) use core::convert::{identity as likely, identity as unlikely};
+// FIXME: Replace with `core::hint::{likely, unlikely}` once they are stable.
 #[cfg(feature = "nightly")]
 pub(crate) use core::intrinsics::{likely, unlikely};
+
+#[cfg(not(feature = "nightly"))]
+#[inline(always)]
+#[cold]
+fn cold_path() {}
+
+#[cfg(not(feature = "nightly"))]
+#[inline(always)]
+pub(crate) fn likely(b: bool) -> bool {
+    if b {
+        true
+    } else {
+        cold_path();
+        false
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+#[inline(always)]
+pub(crate) fn unlikely(b: bool) -> bool {
+    if b {
+        cold_path();
+        true
+    } else {
+        false
+    }
+}
 
 // FIXME: use strict provenance functions once they are stable.
 // Implement it with a transmute for now.


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/120370 `#[cold]` affects branch weights in the backend (again?). Re-implement `likely` and `unlikely` in terms of a `#[cold]` function.

You can verify that the LLVM IR in [this godbolt link](https://godbolt.org/z/n3v7hsMqK) contains a `branch_weights` metadata.

These were removed in https://github.com/rust-lang/hashbrown/commit/d677fd42df6978522045a9561242588ef970ed0c.