### PR TITLE
perf: Bump foldhash to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bump foldhash, the default hasher, to 0.2.0.
+
 ## [0.15.5](https://github.com/rust-lang/hashbrown/compare/v0.15.4...v0.15.5) - 2025-08-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.65.0"
 
 [dependencies]
 # For the default hasher
-foldhash = { version = "0.1.2", default-features = false, optional = true }
+foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.2", optional = true }


### PR DESCRIPTION
Following up from the rapidhash PR #633, this bumps foldhash to `0.2.0` for a large improvement in foldhash's string hashing.

Both rapidhash and foldhash are equal in the hashbrown benchmark suite as it only tests the hashing of `usize` objects.

The reason foldhash 0.2.0 required a major version bump is because `FoldHasher` now has a lifetime parameter. I don't know how users are expected to use `DefaultHashBuilder`, but noting that it likely makes this a breaking change for hashbrown?

cc. @orlp @Amanieu from #633 