### PR TITLE
Change `DefaultHashBuilder` to an opaque newtype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default = ["default-hasher", "inline-more", "allocator-api2", "equivalent", "raw
 
 # Enables use of nightly features. This is only guaranteed to work on the latest
 # version of nightly Rust.
-nightly = ["bumpalo/allocator_api"]
+nightly = ["foldhash?/nightly", "bumpalo/allocator_api"]
 
 # Enables the RustcEntry API used to provide the standard library's Entry API.
 rustc-internal-api = []

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -63,6 +63,13 @@ impl Hasher for DefaultHasher {
         write_isize(isize),
     }
 
+    // feature(hasher_prefixfree_extras)
+    #[cfg(feature = "nightly")]
+    forward_writes! {
+        write_length_prefix(usize),
+        write_str(&str),
+    }
+
     #[inline(always)]
     fn finish(&self) -> u64 {
         self.inner.finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,10 @@
     all(feature = "nightly", target_arch = "loongarch64"),
     feature(stdarch_loongarch)
 )]
+#![cfg_attr(
+    all(feature = "nightly", feature = "default-hasher"),
+    feature(hasher_prefixfree_extras)
+)]
 
 #[cfg(test)]
 #[macro_use]


### PR DESCRIPTION
This hides the underlying hasher as an implementation detail, so it's no
longer a public dependency. A newtype `DefaultHasher` is also added here
to wrap the underlying `<_ as BuildHasher>::Hasher` type.

This is a breaking change now, requiring a semver bump, but it will
allow later changes to the hasher without breaking.
