### PR TITLE
Depend on `serde_core` instead of `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
 rayon = { version = "1.2", optional = true }
-serde = { version = "1.0.25", default-features = false, optional = true }
+serde_core = { version = "1.0.221", default-features = false, optional = true }
 
 # When built as part of libstd
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
@@ -32,6 +32,11 @@ allocator-api2 = { version = "0.2.9", optional = true, default-features = false,
 # Equivalent trait which can be shared with other hash table implementations.
 # NB: this is a public dependency because `Equivalent` is re-exported!
 equivalent = { version = "1.0", optional = true, default-features = false }
+
+# serde v1.0.220 is the first version that released with `serde_core`.
+# This is required to avoid conflict with other `serde` users which may require an older version.
+[target.'cfg(any())'.dependencies]
+serde = { version = "1.0.220", default-features = false, optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4"
@@ -59,6 +64,9 @@ rustc-dep-of-std = [
     "alloc",
     "rustc-internal-api",
 ]
+
+# Enables serde support.
+serde = ["dep:serde_core", "dep:serde"]
 
 # Enables the deprecated RawEntry API.
 raw-entry = []

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -15,8 +15,8 @@ mod map {
     use core::fmt;
     use core::hash::{BuildHasher, Hash};
     use core::marker::PhantomData;
-    use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
-    use serde::ser::{Serialize, Serializer};
+    use serde_core::de::{Deserialize, Deserializer, MapAccess, Visitor};
+    use serde_core::ser::{Serialize, Serializer};
 
     use crate::hash_map::HashMap;
 
@@ -101,8 +101,8 @@ mod set {
     use core::fmt;
     use core::hash::{BuildHasher, Hash};
     use core::marker::PhantomData;
-    use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
-    use serde::ser::{Serialize, Serializer};
+    use serde_core::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+    use serde_core::ser::{Serialize, Serializer};
 
     use crate::hash_set::HashSet;
 


### PR DESCRIPTION
This crate does not make use of serde derive macros, thus it can depend on `serde_core` instead of `serde` to speed up users' compile times.

See the documentation of [`serde_core`](https://docs.rs/serde_core) for more details.