### PR TITLE
fixes #651 -- use rayon's optimized collect_vec_list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.65.0"
 foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
-rayon = { version = "1.2", optional = true }
+rayon = { version = "1.9.0", optional = true }
 serde_core = { version = "1.0.221", default-features = false, optional = true }
 
 # When built as part of libstd

--- a/src/external_trait_impls/rayon/helpers.rs
+++ b/src/external_trait_impls/rayon/helpers.rs
@@ -6,21 +6,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 /// Helper for collecting parallel iterators to an intermediary
 #[allow(clippy::linkedlist)] // yes, we need linked list here for efficient appending!
 pub(super) fn collect<I: IntoParallelIterator>(iter: I) -> (LinkedList<Vec<I::Item>>, usize) {
-    let list = iter
-        .into_par_iter()
-        .fold(Vec::new, |mut vec, elem| {
-            vec.push(elem);
-            vec
-        })
-        .map(|vec| {
-            let mut list = LinkedList::new();
-            list.push_back(vec);
-            list
-        })
-        .reduce(LinkedList::new, |mut list1, mut list2| {
-            list1.append(&mut list2);
-            list1
-        });
+    let list = iter.into_par_iter().collect_vec_list();
 
     let len = list.iter().map(Vec::len).sum();
     (list, len)


### PR DESCRIPTION
this provides more efficient intermediate collection if the parallel iterator is indexable