### PR TITLE
Draft: change SSE2 impl to use 8-bits Tag instead of 7

### DIFF
--- a/src/control/tag.rs
+++ b/src/control/tag.rs
@@ -3,50 +3,79 @@ use core::{fmt, mem};
 /// Single tag in a control group.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(transparent)]
-pub(crate) struct Tag(pub(super) u8);
+pub(crate) struct Tag(pub(super) i8);
 impl Tag {
     /// Control tag value for an empty bucket.
-    pub(crate) const EMPTY: Tag = Tag(0b1111_1111);
+    pub(crate) const EMPTY: Tag = Tag(0b0111_1111); // 127
+    pub(crate) const EMPTY32: i32 = 0x7F7F7F7F;
 
     /// Control tag value for a deleted bucket.
-    pub(crate) const DELETED: Tag = Tag(0b1000_0000);
+    pub(crate) const DELETED: Tag = Tag(0b0111_1110); // 126
+    pub(crate) const DELETED32: i32 = 0x7E7E7E7E;
+
+    pub(crate) const MAX_TAG32: i32 = 0x7D7D7D7D; // 4*125
 
     /// Checks whether a control tag represents a full bucket (top bit is clear).
     #[inline]
     pub(crate) const fn is_full(self) -> bool {
-        self.0 & 0x80 == 0
+        self.0 < Tag::DELETED.0
     }
 
     /// Checks whether a control tag represents a special value (top bit is set).
     #[inline]
     pub(crate) const fn is_special(self) -> bool {
-        self.0 & 0x80 != 0
+        self.0 >= Tag::DELETED.0
     }
 
     /// Checks whether a special control value is EMPTY (just check 1 bit).
     #[inline]
     pub(crate) const fn special_is_empty(self) -> bool {
         debug_assert!(self.is_special());
-        self.0 & 0x01 != 0
+        self.0 == Tag::EMPTY.0
     }
 
     /// Creates a control tag representing a full bucket with the given hash.
-    #[inline]
+    #[inline(always)]
     #[allow(clippy::cast_possible_truncation)]
     pub(crate) const fn full(hash: u64) -> Tag {
-        // Constant for function that grabs the top 7 bits of the hash.
+        Tag(Self::full32(hash) as i8)
+    }
+    
+    #[inline]
+    #[allow(clippy::cast_possible_truncation)]
+    pub(crate) const fn full32(hash: u64) -> i32 {
+        // Constant for function that grabs the top 8 bits * 4 of the hash.
         const MIN_HASH_LEN: usize = if mem::size_of::<usize>() < mem::size_of::<u64>() {
             mem::size_of::<usize>()
         } else {
             mem::size_of::<u64>()
         };
 
-        // Grab the top 7 bits of the hash. While the hash is normally a full 64-bit
+        // Constant array of 8 bits duplicated as 32 bits
+        // with re-mapping of special values.
+        const fn compute_control() -> [i32; 256] {
+            let mut result = [0; 256];
+
+            let mut i: u32 = 0;
+            while i < 256 {
+                result[i as usize] = (i | (i << 8) | (i << 16) | (i << 24)) as i32;
+                i += 1;
+            }
+
+            // Avoid overlap with special values.
+            result[Tag::EMPTY.0 as usize] = 0x29292929;
+            result[Tag::DELETED.0 as usize] = 0x53535353;
+
+            result
+        }
+        const CONTROL: [i32; 256] = compute_control();
+        
+        // Grab the top 8 bits of the hash. While the hash is normally a full 64-bit
         // value, some hash functions (such as FxHash) produce a usize result
         // instead, which means that the top 32 bits are 0 on 32-bit platforms.
         // So we use MIN_HASH_LEN constant to handle this.
-        let top7 = hash >> (MIN_HASH_LEN * 8 - 7);
-        Tag((top7 & 0x7f) as u8) // truncation
+        let top8 = (hash >> (MIN_HASH_LEN * 8 - 8)) as usize;
+        CONTROL[top8] // truncation
     }
 }
 impl fmt::Debug for Tag {
@@ -58,7 +87,7 @@ impl fmt::Debug for Tag {
                 f.pad("DELETED")
             }
         } else {
-            f.debug_tuple("full").field(&(self.0 & 0x7F)).finish()
+            f.debug_tuple("full").field(&self.0).finish()
         }
     }
 }
@@ -78,6 +107,6 @@ impl TagSliceExt for [Tag] {
     #[inline]
     fn fill_tag(&mut self, tag: Tag) {
         // SAFETY: We have access to the entire slice, so, we can write to the entire slice.
-        unsafe { self.as_mut_ptr().write_bytes(tag.0, self.len()) }
+        unsafe { self.as_mut_ptr().write_bytes(tag.0 as u8, self.len()) }
     }
 }


### PR DESCRIPTION
Following #635
Here is a test branch to benchmark an "8-bits Tag" implementation (starting with SSE2).

As seen in results below, for Foldhash:
- lookup-hit is slightly slower (~-2%)
- lookup-fail get a little boost in perf as the table gets filled (~12.5%)

For Std:
- lookup-hit is slightly faster (~3-5%)
- lookup-fail is also a bit faster (~8%)

But the more interesting part might be the iteration results.
Not quite sure the exact reason for it (without proper profiling), but we have a ~35% speed-up.

As the new implementation relies on a static const array to map hash value to tag (which might not be hot in cache), the benchmarks should be taken with a grain of salt compared to in-production scenarios.
But I feel like the iteration gain deserve to be studied.

```
// BEFORE (7-bits Tag)
running 57 tests
test clone_from_large               ... bench:      12,657.55 ns/iter (+/- 136.98)
test clone_from_small               ... bench:         131.76 ns/iter (+/- 1.26)
test clone_large                    ... bench:      12,859.06 ns/iter (+/- 144.42)
test clone_small                    ... bench:         207.03 ns/iter (+/- 2.70)
test grow_insert_foldhash_highbits  ... bench:      38,844.09 ns/iter (+/- 379.59)
test grow_insert_foldhash_random    ... bench:      42,001.36 ns/iter (+/- 427.64)
test grow_insert_foldhash_serial    ... bench:      40,266.52 ns/iter (+/- 383.22)
test grow_insert_std_highbits       ... bench:      71,766.36 ns/iter (+/- 798.64)
test grow_insert_std_random         ... bench:      71,636.36 ns/iter (+/- 778.27)
test grow_insert_std_serial         ... bench:      71,198.46 ns/iter (+/- 615.62)
test insert_erase_foldhash_highbits ... bench:      36,820.00 ns/iter (+/- 401.00)
test insert_erase_foldhash_random   ... bench:      36,681.11 ns/iter (+/- 449.44)
test insert_erase_foldhash_serial   ... bench:      36,260.00 ns/iter (+/- 415.84)
test insert_erase_std_highbits      ... bench:      65,048.33 ns/iter (+/- 749.42)
test insert_erase_std_random        ... bench:      64,969.17 ns/iter (+/- 612.08)
test insert_erase_std_serial        ... bench:      63,380.00 ns/iter (+/- 700.42)
test insert_foldhash_highbits       ... bench:      30,413.33 ns/iter (+/- 666.75)
test insert_foldhash_random         ... bench:      30,216.89 ns/iter (+/- 205.22)
test insert_foldhash_serial         ... bench:      30,227.33 ns/iter (+/- 213.67)
test insert_std_highbits            ... bench:      48,720.43 ns/iter (+/- 455.83)
test insert_std_random              ... bench:      49,116.82 ns/iter (+/- 445.82)
test insert_std_serial              ... bench:      49,087.83 ns/iter (+/- 457.78)
test iter_foldhash_highbits         ... bench:       2,144.10 ns/iter (+/- 35.21)
test iter_foldhash_random           ... bench:       2,309.01 ns/iter (+/- 41.42)
test iter_foldhash_serial           ... bench:       2,282.76 ns/iter (+/- 41.28)
test iter_std_highbits              ... bench:       2,355.90 ns/iter (+/- 39.74)
test iter_std_random                ... bench:       2,310.06 ns/iter (+/- 64.54)
test iter_std_serial                ... bench:       2,311.40 ns/iter (+/- 50.47)
test loadfactor_lookup_14500        ... bench:       3,080.38 ns/iter (+/- 48.16)
test loadfactor_lookup_16500        ... bench:       3,120.47 ns/iter (+/- 33.56)
test loadfactor_lookup_18500        ... bench:       3,071.59 ns/iter (+/- 38.13)
test loadfactor_lookup_20500        ... bench:       3,112.54 ns/iter (+/- 29.97)
test loadfactor_lookup_22500        ... bench:       3,077.02 ns/iter (+/- 31.17)
test loadfactor_lookup_24500        ... bench:       3,123.32 ns/iter (+/- 34.10)
test loadfactor_lookup_26500        ... bench:       3,097.77 ns/iter (+/- 36.29)
test loadfactor_lookup_28500        ... bench:       3,088.45 ns/iter (+/- 36.75)
test loadfactor_lookup_fail_14500   ... bench:       2,653.24 ns/iter (+/- 32.00)
test loadfactor_lookup_fail_16500   ... bench:       2,779.21 ns/iter (+/- 29.43)
test loadfactor_lookup_fail_18500   ... bench:       2,924.01 ns/iter (+/- 30.28)
test loadfactor_lookup_fail_20500   ... bench:       3,220.67 ns/iter (+/- 39.57)
test loadfactor_lookup_fail_22500   ... bench:       3,775.43 ns/iter (+/- 48.63)
test loadfactor_lookup_fail_24500   ... bench:       4,931.71 ns/iter (+/- 57.38)
test loadfactor_lookup_fail_26500   ... bench:       7,343.11 ns/iter (+/- 102.79)
test loadfactor_lookup_fail_28500   ... bench:      11,605.00 ns/iter (+/- 161.62)
test lookup_fail_foldhash_highbits  ... bench:       5,403.08 ns/iter (+/- 61.75)
test lookup_fail_foldhash_random    ... bench:       5,156.32 ns/iter (+/- 10.66)
test lookup_fail_foldhash_serial    ... bench:       5,103.27 ns/iter (+/- 46.52)
test lookup_fail_std_highbits       ... bench:      18,611.51 ns/iter (+/- 172.34)
test lookup_fail_std_random         ... bench:      18,690.19 ns/iter (+/- 36.45)
test lookup_fail_std_serial         ... bench:      18,349.81 ns/iter (+/- 171.23)
test lookup_foldhash_highbits       ... bench:       5,714.35 ns/iter (+/- 46.51)
test lookup_foldhash_random         ... bench:       5,661.02 ns/iter (+/- 41.83)
test lookup_foldhash_serial         ... bench:       5,282.01 ns/iter (+/- 47.31)
test lookup_std_highbits            ... bench:      19,089.80 ns/iter (+/- 130.08)
test lookup_std_random              ... bench:      19,325.10 ns/iter (+/- 128.25)
test lookup_std_serial              ... bench:      18,871.54 ns/iter (+/- 140.92)
test rehash_in_place                ... bench:     411,638.12 ns/iter (+/- 15,060.88)

running 2 tests
test insert                  ... bench:      13,414.26 ns/iter (+/- 155.50)
test insert_unique_unchecked ... bench:      10,216.89 ns/iter (+/- 94.85)

running 10 tests
test set_ops_bit_and                ... bench:      15,200.38 ns/iter (+/- 115.83)
test set_ops_bit_and_assign         ... bench:      11,075.67 ns/iter (+/- 32.88)
test set_ops_bit_or                 ... bench:     121,849.25 ns/iter (+/- 721.05)
test set_ops_bit_or_assign          ... bench:      99,121.43 ns/iter (+/- 1,543.14)
test set_ops_bit_xor                ... bench:     127,540.83 ns/iter (+/- 4,612.75)
test set_ops_bit_xor_assign         ... bench:      99,960.00 ns/iter (+/- 1,572.29)
test set_ops_sub_assign_large_small ... bench:      98,311.43 ns/iter (+/- 1,693.29)
test set_ops_sub_assign_small_large ... bench:      11,274.10 ns/iter (+/- 98.62)
test set_ops_sub_large_small        ... bench:     127,703.33 ns/iter (+/- 1,757.83)
test set_ops_sub_small_large        ... bench:       1,592.34 ns/iter (+/- 19.71)
```
Vs
```
// AFTER (8-bits Tag)
Running benches\bench.rs (target\release\deps\bench-2c0ae950998258dc.exe)

running 57 tests
test clone_from_large               ... bench:      12,717.72 ns/iter (+/- 114.61)
test clone_from_small               ... bench:         131.72 ns/iter (+/- 0.72)
test clone_large                    ... bench:      13,012.22 ns/iter (+/- 279.33)
test clone_small                    ... bench:         207.25 ns/iter (+/- 3.09)
test grow_insert_foldhash_highbits  ... bench:      42,258.00 ns/iter (+/- 363.40)
test grow_insert_foldhash_random    ... bench:      42,671.36 ns/iter (+/- 441.41)
test grow_insert_foldhash_serial    ... bench:      40,586.52 ns/iter (+/- 361.26)
test grow_insert_std_highbits       ... bench:      72,596.36 ns/iter (+/- 793.91)
test grow_insert_std_random         ... bench:      72,523.08 ns/iter (+/- 639.77)
test grow_insert_std_serial         ... bench:      72,351.54 ns/iter (+/- 646.62)
test insert_erase_foldhash_highbits ... bench:      37,095.33 ns/iter (+/- 441.00)
test insert_erase_foldhash_random   ... bench:      37,033.75 ns/iter (+/- 553.25)
test insert_erase_foldhash_serial   ... bench:      36,694.50 ns/iter (+/- 444.00)
test insert_erase_std_highbits      ... bench:      65,396.67 ns/iter (+/- 642.42)
test insert_erase_std_random        ... bench:      65,792.50 ns/iter (+/- 632.17)
test insert_erase_std_serial        ... bench:      65,388.33 ns/iter (+/- 612.25)
test insert_foldhash_highbits       ... bench:      30,409.17 ns/iter (+/- 326.58)
test insert_foldhash_random         ... bench:      30,762.73 ns/iter (+/- 220.45)
test insert_foldhash_serial         ... bench:      30,995.33 ns/iter (+/- 245.04)
test insert_std_highbits            ... bench:      48,786.82 ns/iter (+/- 407.00)
test insert_std_random              ... bench:      49,355.91 ns/iter (+/- 408.41)
test insert_std_serial              ... bench:      48,913.18 ns/iter (+/- 439.14)
test iter_foldhash_highbits         ... bench:       1,688.02 ns/iter (+/- 26.88)
test iter_foldhash_random           ... bench:       1,689.84 ns/iter (+/- 23.44)
test iter_foldhash_serial           ... bench:       1,681.17 ns/iter (+/- 39.69)
test iter_std_highbits              ... bench:       1,662.24 ns/iter (+/- 33.39)
test iter_std_random                ... bench:       1,652.95 ns/iter (+/- 3.03)
test iter_std_serial                ... bench:       1,650.71 ns/iter (+/- 15.33)
test loadfactor_lookup_14500        ... bench:       3,128.97 ns/iter (+/- 46.94)
test loadfactor_lookup_16500        ... bench:       3,150.54 ns/iter (+/- 34.80)
test loadfactor_lookup_18500        ... bench:       3,181.06 ns/iter (+/- 44.53)
test loadfactor_lookup_20500        ... bench:       3,167.33 ns/iter (+/- 33.99)
test loadfactor_lookup_22500        ... bench:       3,171.40 ns/iter (+/- 27.92)
test loadfactor_lookup_24500        ... bench:       3,144.05 ns/iter (+/- 34.27)
test loadfactor_lookup_26500        ... bench:       3,168.11 ns/iter (+/- 37.73)
test loadfactor_lookup_28500        ... bench:       3,127.07 ns/iter (+/- 32.85)
test loadfactor_lookup_fail_14500   ... bench:       2,295.21 ns/iter (+/- 34.08)
test loadfactor_lookup_fail_16500   ... bench:       2,372.33 ns/iter (+/- 16.12)
test loadfactor_lookup_fail_18500   ... bench:       2,523.12 ns/iter (+/- 31.05)
test loadfactor_lookup_fail_20500   ... bench:       2,776.58 ns/iter (+/- 15.96)
test loadfactor_lookup_fail_22500   ... bench:       3,293.93 ns/iter (+/- 9.05)
test loadfactor_lookup_fail_24500   ... bench:       4,389.17 ns/iter (+/- 51.16)
test loadfactor_lookup_fail_26500   ... bench:       6,520.49 ns/iter (+/- 82.83)
test loadfactor_lookup_fail_28500   ... bench:      10,327.45 ns/iter (+/- 123.22)
test lookup_fail_foldhash_highbits  ... bench:       4,580.48 ns/iter (+/- 49.10)
test lookup_fail_foldhash_random    ... bench:       4,645.15 ns/iter (+/- 44.44)
test lookup_fail_foldhash_serial    ... bench:       4,524.91 ns/iter (+/- 20.92)
test lookup_fail_std_highbits       ... bench:      17,468.55 ns/iter (+/- 136.31)
test lookup_fail_std_random         ... bench:      17,285.09 ns/iter (+/- 36.36)
test lookup_fail_std_serial         ... bench:      17,238.77 ns/iter (+/- 141.75)
test lookup_foldhash_highbits       ... bench:       5,598.82 ns/iter (+/- 46.34)
test lookup_foldhash_random         ... bench:       5,554.56 ns/iter (+/- 14.40)
test lookup_foldhash_serial         ... bench:       5,506.69 ns/iter (+/- 39.15)
test lookup_std_highbits            ... bench:      18,487.12 ns/iter (+/- 151.31)
test lookup_std_random              ... bench:      18,336.98 ns/iter (+/- 145.79)
test lookup_std_serial              ... bench:      18,272.94 ns/iter (+/- 46.86)
test rehash_in_place                ... bench:     397,508.75 ns/iter (+/- 20,795.19)

running 2 tests
test insert                  ... bench:      13,527.58 ns/iter (+/- 102.34)
test insert_unique_unchecked ... bench:      11,386.02 ns/iter (+/- 129.57)

running 10 tests
test set_ops_bit_and                ... bench:      15,375.37 ns/iter (+/- 130.88)
test set_ops_bit_and_assign         ... bench:      11,078.62 ns/iter (+/- 97.75)
test set_ops_bit_or                 ... bench:     123,941.56 ns/iter (+/- 1,511.09)
test set_ops_bit_or_assign          ... bench:      98,770.00 ns/iter (+/- 1,370.00)
test set_ops_bit_xor                ... bench:     122,981.67 ns/iter (+/- 1,234.83)
test set_ops_bit_xor_assign         ... bench:      98,363.89 ns/iter (+/- 882.89)
test set_ops_sub_assign_large_small ... bench:      98,177.14 ns/iter (+/- 1,634.14)
test set_ops_sub_assign_small_large ... bench:      11,438.95 ns/iter (+/- 112.68)
test set_ops_sub_large_small        ... bench:     121,118.33 ns/iter (+/- 1,882.50)
test set_ops_sub_small_large        ... bench:       1,566.15 ns/iter (+/- 24.13)
```