### PR TITLE
style: Add rustfmt configuration

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
+
+edition = "2021"


### PR DESCRIPTION
I'm using a different style targeting the 2024 edition and it results in many unintended changes.

TESTED=I ran `cargo fmt --all` and it resulted in no changes.