### PR TITLE
refactor: fix typo in comment

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -2513,7 +2513,7 @@ impl RawTableInner {
 
     /// Gets the slice of all control bytes.
     fn ctrl_slice(&mut self) -> &mut [Tag] {
-        // SAFETY: We've intiailized all control bytes, and have the correct number.
+        // SAFETY: We've initialized all control bytes, and have the correct number.
         unsafe { slice::from_raw_parts_mut(self.ctrl.as_ptr().cast(), self.num_ctrl_bytes()) }
     }
 


### PR DESCRIPTION
Just fixes a spelling mistake.