### PR TITLE
Add integration with Paralight

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ str_to_string = "warn"
 foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
-paralight = { version = "0.0.10", optional = true }
+paralight = { version = "0.0.11", optional = true }
 rayon = { version = "1.9.0", optional = true }
 serde_core = { version = "1.0.221", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ str_to_string = "warn"
 foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
-paralight = { version = "0.0.6", optional = true }
+paralight = { version = "0.0.10", optional = true }
 rayon = { version = "1.9.0", optional = true }
 serde_core = { version = "1.0.221", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ str_to_string = "warn"
 foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
+paralight = { version = "0.0.6", optional = true }
 rayon = { version = "1.9.0", optional = true }
 serde_core = { version = "1.0.221", default-features = false, optional = true }
 
@@ -122,5 +123,5 @@ name = "bench"
 harness = false
 
 [package.metadata.docs.rs]
-features = ["nightly", "rayon", "serde", "raw-entry"]
+features = ["nightly", "paralight", "rayon", "serde", "raw-entry"]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ str_to_string = "warn"
 foldhash = { version = "0.2.0", default-features = false, optional = true }
 
 # For external trait impls
-paralight = { version = "0.0.11", optional = true }
+paralight = { version = "0.0.12", optional = true }
 rayon = { version = "1.9.0", optional = true }
 serde_core = { version = "1.0.221", default-features = false, optional = true }
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This crate has the following Cargo features:
 - `nightly`: Enables nightly-only features including: `#[may_dangle]`.
 - `serde`: Enables serde serialization support.
 - `rayon`: Enables rayon parallel iterator support.
+- `paralight`: Enables paralight parallel iterator support.
 - `equivalent`: Allows comparisons to be customized with the `Equivalent` trait.
   (enabled by default)
 - `raw-entry`: Enables access to the deprecated `RawEntry` API.

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,7 +33,7 @@ if [ "${NO_STD}" = "1" ]; then
     FEATURES="rustc-internal-api"
     OP="build"
 else
-    FEATURES="rustc-internal-api,serde,rayon"
+    FEATURES="rustc-internal-api,serde,rayon,paralight"
     OP="test"
 fi
 

--- a/ci/tools.sh
+++ b/ci/tools.sh
@@ -29,7 +29,7 @@ if rustc --version | grep --quiet nightly ; then
     export RUSTDOCFLAGS="-Zunstable-options --check"
 fi
 
-cargo doc --no-deps --features serde,rayon
+cargo doc --no-deps --features serde,rayon,paralight
 
 if retry rustup component add rustfmt ; then
     cargo fmt --all -- --check
@@ -92,11 +92,11 @@ if retry rustup component add clippy ; then
         TARGETS+=(--target i586-unknown-linux-gnu)
     fi
 
-    cargo clippy --all --tests --features serde,rayon "${TARGETS[@]}" -- -D warnings
+    cargo clippy --all --tests --features serde,rayon,paralight "${TARGETS[@]}" -- -D warnings
 
     # check nightly too
     if rustc --version | grep --quiet nightly ; then
-        cargo +nightly clippy --all-targets --features serde,rayon,nightly "${TARGETS[@]}" -- -D warnings
+        cargo +nightly clippy --all-targets --features serde,rayon,paralight,nightly "${TARGETS[@]}" -- -D warnings
     fi
 fi
 

--- a/src/external_trait_impls/mod.rs
+++ b/src/external_trait_impls/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "paralight")]
+mod paralight;
 #[cfg(feature = "rayon")]
 pub(crate) mod rayon;
 #[cfg(feature = "serde")]

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -4,7 +4,7 @@
     clippy::undocumented_unsafe_blocks
 )]
 
-use crate::raw::Allocator;
+use crate::alloc::Allocator;
 use crate::{HashMap, HashSet};
 use paralight::iter::{
     IntoParallelRefMutSource, IntoParallelRefSource, IntoParallelSource, ParallelSource,
@@ -477,7 +477,8 @@ impl<K, V, A: Allocator> Drop for HashMapSourceDescriptor<K, V, A> {
 }
 
 mod raw_table_wrapper {
-    use crate::raw::{Allocator, RawTable};
+    use crate::alloc::Allocator;
+    use crate::raw::RawTable;
 
     /// Helper to implement HashSet::par_iter().
     pub(super) struct HashSetRef<'data, T, A: Allocator> {
@@ -550,12 +551,12 @@ mod raw_table_wrapper {
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloc::boxed::Box;
     use core::cell::Cell;
     use core::ops::Deref;
     use paralight::iter::{ParallelIteratorExt, ParallelSourceExt};
     use paralight::threads::{CpuPinningPolicy, RangeStrategy, ThreadCount, ThreadPoolBuilder};
     use std::hash::{Hash, Hasher};
+    use stdalloc::boxed::Box;
 
     // A cell that implements Hash.
     #[derive(PartialEq, Eq)]

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -390,17 +390,17 @@ mod test {
 
     #[test]
     fn test_set_par_iter() {
-        let mut set = HashSet::new();
-        for i in 1..=42 {
-            set.insert(Box::new(i));
-        }
-
         let mut thread_pool = ThreadPoolBuilder {
             num_threads: ThreadCount::AvailableParallelism,
             range_strategy: RangeStrategy::WorkStealing,
             cpu_pinning: CpuPinningPolicy::No,
         }
         .build();
+
+        let mut set = HashSet::new();
+        for i in 1..=42 {
+            set.insert(Box::new(i));
+        }
 
         let sum = set
             .par_iter()
@@ -412,17 +412,17 @@ mod test {
 
     #[test]
     fn test_set_into_par_iter() {
-        let mut set = HashSet::new();
-        for i in 1..=42 {
-            set.insert(Box::new(i));
-        }
-
         let mut thread_pool = ThreadPoolBuilder {
             num_threads: ThreadCount::AvailableParallelism,
             range_strategy: RangeStrategy::WorkStealing,
             cpu_pinning: CpuPinningPolicy::No,
         }
         .build();
+
+        let mut set = HashSet::new();
+        for i in 1..=42 {
+            set.insert(Box::new(i));
+        }
 
         let sum = set
             .into_par_iter()
@@ -434,17 +434,17 @@ mod test {
 
     #[test]
     fn test_map_par_iter() {
-        let mut map = HashMap::new();
-        for i in 1..=42 {
-            map.insert(Box::new(i), Box::new(i * i));
-        }
-
         let mut thread_pool = ThreadPoolBuilder {
             num_threads: ThreadCount::AvailableParallelism,
             range_strategy: RangeStrategy::WorkStealing,
             cpu_pinning: CpuPinningPolicy::No,
         }
         .build();
+
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Box::new(i * i));
+        }
 
         map.par_iter()
             .with_thread_pool(&mut thread_pool)
@@ -454,17 +454,17 @@ mod test {
 
     #[test]
     fn test_map_par_iter_mut() {
-        let mut map = HashMap::new();
-        for i in 1..=42 {
-            map.insert(Box::new(i), Box::new(i));
-        }
-
         let mut thread_pool = ThreadPoolBuilder {
             num_threads: ThreadCount::AvailableParallelism,
             range_strategy: RangeStrategy::WorkStealing,
             cpu_pinning: CpuPinningPolicy::No,
         }
         .build();
+
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Box::new(i));
+        }
 
         map.par_iter_mut()
             .with_thread_pool(&mut thread_pool)
@@ -478,17 +478,17 @@ mod test {
 
     #[test]
     fn test_map_into_par_iter() {
-        let mut map = HashMap::new();
-        for i in 1..=42 {
-            map.insert(Box::new(i), Box::new(i * i));
-        }
-
         let mut thread_pool = ThreadPoolBuilder {
             num_threads: ThreadCount::AvailableParallelism,
             range_strategy: RangeStrategy::WorkStealing,
             cpu_pinning: CpuPinningPolicy::No,
         }
         .build();
+
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Box::new(i * i));
+        }
 
         map.into_par_iter()
             .with_thread_pool(&mut thread_pool)

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -135,8 +135,7 @@ impl<'data, K: Sync, V: Sync, A: Allocator> SourceDescriptor
 }
 
 // HashMap.par_iter_mut()
-// TODO: Remove Sync requirement on V.
-impl<'data, K: Sync + 'data, V: Send + Sync + 'data, S: 'data, A: Allocator + Sync + 'data>
+impl<'data, K: Sync + 'data, V: Send + 'data, S: 'data, A: Allocator + Sync + 'data>
     IntoParallelRefMutSource<'data> for HashMap<K, V, S, A>
 {
     type Item = (&'data K, &'data mut V);
@@ -152,29 +151,29 @@ pub struct HashMapRefMutParallelSource<'data, K, V, S, A: Allocator> {
     hash_map: &'data mut HashMap<K, V, S, A>,
 }
 
-impl<'data, K: Sync, V: Send + Sync, S, A: Allocator + Sync> ParallelSource
+impl<'data, K: Sync, V: Send, S, A: Allocator + Sync> ParallelSource
     for HashMapRefMutParallelSource<'data, K, V, S, A>
 {
     type Item = (&'data K, &'data mut V);
 
     fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
         HashMapRefMutSourceDescriptor {
-            table: &self.hash_map.table,
+            table: raw_table_wrapper::HashMapRefMut {
+                inner: &self.hash_map.table,
+            },
         }
     }
 }
 
-struct HashMapRefMutSourceDescriptor<'data, K: Sync, V: Send + Sync, A: Allocator> {
-    table: &'data RawTable<(K, V), A>,
+struct HashMapRefMutSourceDescriptor<'data, K: Sync, V: Send, A: Allocator> {
+    table: raw_table_wrapper::HashMapRefMut<'data, K, V, A>,
 }
 
-impl<K: Sync, V: Send + Sync, A: Allocator> SourceCleanup
-    for HashMapRefMutSourceDescriptor<'_, K, V, A>
-{
+impl<K: Sync, V: Send, A: Allocator> SourceCleanup for HashMapRefMutSourceDescriptor<'_, K, V, A> {
     const NEEDS_CLEANUP: bool = false;
 
     fn len(&self) -> usize {
-        self.table.buckets()
+        self.table.inner.buckets()
     }
 
     unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
@@ -182,7 +181,7 @@ impl<K: Sync, V: Send + Sync, A: Allocator> SourceCleanup
     }
 }
 
-impl<'data, K: Sync, V: Send + Sync, A: Allocator> SourceDescriptor
+impl<'data, K: Sync, V: Send, A: Allocator> SourceDescriptor
     for HashMapRefMutSourceDescriptor<'data, K, V, A>
 {
     type Item = (&'data K, &'data mut V);
@@ -190,10 +189,10 @@ impl<'data, K: Sync, V: Send + Sync, A: Allocator> SourceDescriptor
     unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: TODO
-        let full = unsafe { self.table.is_bucket_full(index) };
+        let full = unsafe { self.table.inner.is_bucket_full(index) };
         if full {
             // SAFETY: TODO
-            let bucket = unsafe { self.table.bucket(index) };
+            let bucket = unsafe { self.table.inner.bucket(index) };
             // SAFETY: TODO
             let (key, value) = unsafe { bucket.as_mut() };
             Some((key, value))
@@ -204,8 +203,7 @@ impl<'data, K: Sync, V: Send + Sync, A: Allocator> SourceDescriptor
 }
 
 // HashSet.into_par_iter()
-// TODO: Remove Sync requirement on T.
-impl<T: Send + Sync, S, A: Allocator + Sync> IntoParallelSource for HashSet<T, S, A> {
+impl<T: Send, S, A: Allocator + Sync> IntoParallelSource for HashSet<T, S, A> {
     type Item = T;
     type Source = HashSetParallelSource<T, S, A>;
 
@@ -219,25 +217,27 @@ pub struct HashSetParallelSource<T, S, A: Allocator> {
     hash_set: HashSet<T, S, A>,
 }
 
-impl<T: Send + Sync, S, A: Allocator + Sync> ParallelSource for HashSetParallelSource<T, S, A> {
+impl<T: Send, S, A: Allocator + Sync> ParallelSource for HashSetParallelSource<T, S, A> {
     type Item = T;
 
     fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
         HashSetSourceDescriptor {
-            table: self.hash_set.map.table,
+            table: raw_table_wrapper::HashSet {
+                inner: self.hash_set.map.table,
+            },
         }
     }
 }
 
 struct HashSetSourceDescriptor<T, A: Allocator> {
-    table: RawTable<(T, ()), A>,
+    table: raw_table_wrapper::HashSet<T, A>,
 }
 
-impl<T: Send + Sync, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, A> {
+impl<T: Send, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, A> {
     const NEEDS_CLEANUP: bool = core::mem::needs_drop::<T>();
 
     fn len(&self) -> usize {
-        self.table.buckets()
+        self.table.inner.buckets()
     }
 
     unsafe fn cleanup_item_range(&self, range: core::ops::Range<usize>) {
@@ -247,10 +247,10 @@ impl<T: Send + Sync, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, 
             debug_assert!(range.end <= self.len());
             for index in range {
                 // SAFETY: TODO
-                let full = unsafe { self.table.is_bucket_full(index) };
+                let full = unsafe { self.table.inner.is_bucket_full(index) };
                 if full {
                     // SAFETY: TODO
-                    let bucket = unsafe { self.table.bucket(index) };
+                    let bucket = unsafe { self.table.inner.bucket(index) };
                     // SAFETY: TODO
                     let (t, ()) = unsafe { bucket.read() };
                     drop(t);
@@ -260,16 +260,16 @@ impl<T: Send + Sync, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, 
     }
 }
 
-impl<T: Send + Sync, A: Allocator> SourceDescriptor for HashSetSourceDescriptor<T, A> {
+impl<T: Send, A: Allocator> SourceDescriptor for HashSetSourceDescriptor<T, A> {
     type Item = T;
 
     unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: TODO
-        let full = unsafe { self.table.is_bucket_full(index) };
+        let full = unsafe { self.table.inner.is_bucket_full(index) };
         if full {
             // SAFETY: TODO
-            let bucket = unsafe { self.table.bucket(index) };
+            let bucket = unsafe { self.table.inner.bucket(index) };
             // SAFETY: TODO
             let (t, ()) = unsafe { bucket.read() };
             Some(t)
@@ -284,15 +284,12 @@ impl<T, A: Allocator> Drop for HashSetSourceDescriptor<T, A> {
         // Paralight already dropped each missing bucket via calls to cleanup_item_range(), so we
         // can simply mark all buckets as cleared and let the RawTable destructor do the rest.
         // TODO: Optimize this to simply deallocate without touching the control bytes.
-        self.table.clear_no_drop();
+        self.table.inner.clear_no_drop();
     }
 }
 
 // HashMap.into_par_iter()
-// TODO: Remove Sync requirement on K and V.
-impl<K: Send + Sync, V: Send + Sync, S, A: Allocator + Sync> IntoParallelSource
-    for HashMap<K, V, S, A>
-{
+impl<K: Send, V: Send, S, A: Allocator + Sync> IntoParallelSource for HashMap<K, V, S, A> {
     type Item = (K, V);
     type Source = HashMapParallelSource<K, V, S, A>;
 
@@ -306,29 +303,29 @@ pub struct HashMapParallelSource<K, V, S, A: Allocator> {
     hash_map: HashMap<K, V, S, A>,
 }
 
-impl<K: Send + Sync, V: Send + Sync, S, A: Allocator + Sync> ParallelSource
+impl<K: Send, V: Send, S, A: Allocator + Sync> ParallelSource
     for HashMapParallelSource<K, V, S, A>
 {
     type Item = (K, V);
 
     fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
         HashMapSourceDescriptor {
-            table: self.hash_map.table,
+            table: raw_table_wrapper::HashMap {
+                inner: self.hash_map.table,
+            },
         }
     }
 }
 
 struct HashMapSourceDescriptor<K, V, A: Allocator> {
-    table: RawTable<(K, V), A>,
+    table: raw_table_wrapper::HashMap<K, V, A>,
 }
 
-impl<K: Send + Sync, V: Send + Sync, A: Allocator> SourceCleanup
-    for HashMapSourceDescriptor<K, V, A>
-{
+impl<K: Send, V: Send, A: Allocator> SourceCleanup for HashMapSourceDescriptor<K, V, A> {
     const NEEDS_CLEANUP: bool = core::mem::needs_drop::<(K, V)>();
 
     fn len(&self) -> usize {
-        self.table.buckets()
+        self.table.inner.buckets()
     }
 
     unsafe fn cleanup_item_range(&self, range: core::ops::Range<usize>) {
@@ -338,10 +335,10 @@ impl<K: Send + Sync, V: Send + Sync, A: Allocator> SourceCleanup
             debug_assert!(range.end <= self.len());
             for index in range {
                 // SAFETY: TODO
-                let full = unsafe { self.table.is_bucket_full(index) };
+                let full = unsafe { self.table.inner.is_bucket_full(index) };
                 if full {
                     // SAFETY: TODO
-                    let bucket = unsafe { self.table.bucket(index) };
+                    let bucket = unsafe { self.table.inner.bucket(index) };
                     // SAFETY: TODO
                     let key_value = unsafe { bucket.read() };
                     drop(key_value);
@@ -351,18 +348,16 @@ impl<K: Send + Sync, V: Send + Sync, A: Allocator> SourceCleanup
     }
 }
 
-impl<K: Send + Sync, V: Send + Sync, A: Allocator> SourceDescriptor
-    for HashMapSourceDescriptor<K, V, A>
-{
+impl<K: Send, V: Send, A: Allocator> SourceDescriptor for HashMapSourceDescriptor<K, V, A> {
     type Item = (K, V);
 
     unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: TODO
-        let full = unsafe { self.table.is_bucket_full(index) };
+        let full = unsafe { self.table.inner.is_bucket_full(index) };
         if full {
             // SAFETY: TODO
-            let bucket = unsafe { self.table.bucket(index) };
+            let bucket = unsafe { self.table.inner.bucket(index) };
             // SAFETY: TODO
             unsafe { Some(bucket.read()) }
         } else {
@@ -376,17 +371,64 @@ impl<K, V, A: Allocator> Drop for HashMapSourceDescriptor<K, V, A> {
         // Paralight already dropped each missing bucket via calls to cleanup_item_range(), so we
         // can simply mark all buckets as cleared and let the RawTable destructor do the rest.
         // TODO: Optimize this to simply deallocate without touching the control bytes.
-        self.table.clear_no_drop();
+        self.table.inner.clear_no_drop();
     }
+}
+
+mod raw_table_wrapper {
+    use crate::raw::{Allocator, RawTable};
+
+    pub(super) struct HashSet<T, A: Allocator> {
+        pub(super) inner: RawTable<(T, ()), A>,
+    }
+
+    // TODO: Does the Allocator need to be Sync too?
+    unsafe impl<T: Send, A: Allocator + Sync> Sync for HashSet<T, A> {}
+
+    pub(super) struct HashMap<K, V, A: Allocator> {
+        pub(super) inner: RawTable<(K, V), A>,
+    }
+
+    // TODO: Does the Allocator need to be Sync too?
+    unsafe impl<K: Send, V: Send, A: Allocator + Sync> Sync for HashMap<K, V, A> {}
+
+    pub(super) struct HashMapRefMut<'data, K, V, A: Allocator> {
+        pub(super) inner: &'data RawTable<(K, V), A>,
+    }
+
+    // TODO: Does the Allocator need to be Sync too?
+    unsafe impl<'data, K: Sync, V: Send, A: Allocator + Sync> Sync for HashMapRefMut<'data, K, V, A> {}
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use alloc::boxed::Box;
+    use core::cell::Cell;
     use core::ops::Deref;
     use paralight::iter::{ParallelIteratorExt, ParallelSourceExt};
     use paralight::threads::{CpuPinningPolicy, RangeStrategy, ThreadCount, ThreadPoolBuilder};
+    use std::hash::{Hash, Hasher};
+
+    // A cell that implements Hash.
+    #[derive(PartialEq, Eq)]
+    struct HashCell<T: Copy>(Cell<T>);
+
+    impl<T: Copy> HashCell<T> {
+        fn new(t: T) -> Self {
+            Self(Cell::new(t))
+        }
+
+        fn get(&self) -> T {
+            self.0.get()
+        }
+    }
+
+    impl<T: Copy + Hash> Hash for HashCell<T> {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.0.get().hash(state)
+        }
+    }
 
     #[test]
     fn test_set_par_iter() {
@@ -428,6 +470,28 @@ mod test {
             .into_par_iter()
             .with_thread_pool(&mut thread_pool)
             .map(|x| *x)
+            .sum::<i32>();
+        assert_eq!(sum, 21 * 43);
+    }
+
+    #[test]
+    fn test_set_into_par_iter_send() {
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        let mut set = HashSet::new();
+        for i in 1..=42 {
+            set.insert(HashCell::new(i));
+        }
+
+        let sum = set
+            .into_par_iter()
+            .with_thread_pool(&mut thread_pool)
+            .map(|x| x.get())
             .sum::<i32>();
         assert_eq!(sum, 21 * 43);
     }
@@ -475,6 +539,29 @@ mod test {
     }
 
     #[test]
+    fn test_map_par_iter_mut_send_sync() {
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Cell::new(i));
+        }
+
+        map.par_iter_mut()
+            .with_thread_pool(&mut thread_pool)
+            .for_each(|(k, v)| *v.get_mut() *= **k);
+
+        for (k, v) in map.iter() {
+            assert_eq!(**k * **k, v.get());
+        }
+    }
+
+    #[test]
     fn test_map_into_par_iter() {
         let mut thread_pool = ThreadPoolBuilder {
             num_threads: ThreadCount::AvailableParallelism,
@@ -491,5 +578,24 @@ mod test {
         map.into_par_iter()
             .with_thread_pool(&mut thread_pool)
             .for_each(|(k, v)| assert_eq!(*k * *k, *v));
+    }
+
+    #[test]
+    fn test_map_into_par_iter_send() {
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(HashCell::new(i), Cell::new(i * i));
+        }
+
+        map.into_par_iter()
+            .with_thread_pool(&mut thread_pool)
+            .for_each(|(k, v)| assert_eq!(k.get() * k.get(), v.get()));
     }
 }

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -48,7 +48,7 @@ impl<T: Sync, A: Allocator> SourceCleanup for HashSetRefSourceDescriptor<'_, T, 
     const NEEDS_CLEANUP: bool = false;
 
     fn len(&self) -> usize {
-        self.table.inner.buckets()
+        self.table.inner.num_buckets()
     }
 
     unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
@@ -121,7 +121,7 @@ impl<K: Sync, V: Sync, A: Allocator> SourceCleanup for HashMapRefSourceDescripto
     const NEEDS_CLEANUP: bool = false;
 
     fn len(&self) -> usize {
-        self.table.inner.buckets()
+        self.table.inner.num_buckets()
     }
 
     unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
@@ -195,7 +195,7 @@ impl<K: Sync, V: Send, A: Allocator> SourceCleanup for HashMapRefMutSourceDescri
     const NEEDS_CLEANUP: bool = false;
 
     fn len(&self) -> usize {
-        self.table.inner.buckets()
+        self.table.inner.num_buckets()
     }
 
     unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
@@ -274,7 +274,7 @@ impl<T: Send, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, A> {
     const NEEDS_CLEANUP: bool = core::mem::needs_drop::<T>();
 
     fn len(&self) -> usize {
-        self.table.inner.buckets()
+        self.table.inner.num_buckets()
     }
 
     unsafe fn cleanup_item_range(&self, range: core::ops::Range<usize>) {
@@ -392,7 +392,7 @@ impl<K: Send, V: Send, A: Allocator> SourceCleanup for HashMapSourceDescriptor<K
     const NEEDS_CLEANUP: bool = core::mem::needs_drop::<(K, V)>();
 
     fn len(&self) -> usize {
-        self.table.inner.buckets()
+        self.table.inner.num_buckets()
     }
 
     unsafe fn cleanup_item_range(&self, range: core::ops::Range<usize>) {

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -1,8 +1,8 @@
 use crate::raw::{Allocator, RawTable};
 use crate::{HashMap, HashSet};
 use paralight::iter::{
-    IntoParallelRefMutSource, IntoParallelRefSource, ParallelSource, SourceCleanup,
-    SourceDescriptor,
+    IntoParallelRefMutSource, IntoParallelRefSource, IntoParallelSource, ParallelSource,
+    SourceCleanup, SourceDescriptor,
 };
 
 // HashSet.par_iter()
@@ -203,6 +203,183 @@ impl<'data, K: Sync, V: Send + Sync, A: Allocator> SourceDescriptor
     }
 }
 
+// HashSet.into_par_iter()
+// TODO: Remove Sync requirement on T.
+impl<T: Send + Sync, S, A: Allocator + Sync> IntoParallelSource for HashSet<T, S, A> {
+    type Item = Option<T>;
+    type Source = HashSetParallelSource<T, S, A>;
+
+    fn into_par_iter(self) -> Self::Source {
+        HashSetParallelSource { hash_set: self }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy"]
+pub struct HashSetParallelSource<T, S, A: Allocator> {
+    hash_set: HashSet<T, S, A>,
+}
+
+impl<T: Send + Sync, S, A: Allocator + Sync> ParallelSource for HashSetParallelSource<T, S, A> {
+    type Item = Option<T>;
+
+    fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
+        HashSetSourceDescriptor {
+            table: self.hash_set.map.table,
+        }
+    }
+}
+
+struct HashSetSourceDescriptor<T, A: Allocator> {
+    table: RawTable<(T, ()), A>,
+}
+
+impl<T: Send + Sync, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, A> {
+    const NEEDS_CLEANUP: bool = core::mem::needs_drop::<T>();
+
+    unsafe fn cleanup_item_range(&self, range: core::ops::Range<usize>) {
+        if Self::NEEDS_CLEANUP {
+            debug_assert!(range.start <= range.end);
+            debug_assert!(range.start <= self.len());
+            debug_assert!(range.end <= self.len());
+            for index in range {
+                // SAFETY: TODO
+                let full = unsafe { self.table.is_bucket_full(index) };
+                if full {
+                    // SAFETY: TODO
+                    let bucket = unsafe { self.table.bucket(index) };
+                    // SAFETY: TODO
+                    let (t, ()) = unsafe { bucket.read() };
+                    drop(t);
+                }
+            }
+        }
+    }
+}
+
+impl<T: Send + Sync, A: Allocator> SourceDescriptor for HashSetSourceDescriptor<T, A> {
+    type Item = Option<T>;
+
+    fn len(&self) -> usize {
+        self.table.buckets()
+    }
+
+    unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        debug_assert!(index < self.len());
+        // SAFETY: TODO
+        let full = unsafe { self.table.is_bucket_full(index) };
+        if full {
+            // SAFETY: TODO
+            let bucket = unsafe { self.table.bucket(index) };
+            // SAFETY: TODO
+            let (t, ()) = unsafe { bucket.read() };
+            Some(t)
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, A: Allocator> Drop for HashSetSourceDescriptor<T, A> {
+    fn drop(&mut self) {
+        // Paralight already dropped each missing bucket via calls to cleanup_item_range(), so we
+        // can simply mark all buckets as cleared and let the RawTable destructor do the rest.
+        // TODO: Optimize this to simply deallocate without touching the control bytes.
+        self.table.clear_no_drop();
+    }
+}
+
+// HashMap.into_par_iter()
+// TODO: Remove Sync requirement on K and V.
+impl<K: Send + Sync, V: Send + Sync, S, A: Allocator + Sync> IntoParallelSource
+    for HashMap<K, V, S, A>
+{
+    type Item = Option<(K, V)>;
+    type Source = HashMapParallelSource<K, V, S, A>;
+
+    fn into_par_iter(self) -> Self::Source {
+        HashMapParallelSource { hash_map: self }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy"]
+pub struct HashMapParallelSource<K, V, S, A: Allocator> {
+    hash_map: HashMap<K, V, S, A>,
+}
+
+impl<K: Send + Sync, V: Send + Sync, S, A: Allocator + Sync> ParallelSource
+    for HashMapParallelSource<K, V, S, A>
+{
+    type Item = Option<(K, V)>;
+
+    fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
+        HashMapSourceDescriptor {
+            table: self.hash_map.table,
+        }
+    }
+}
+
+struct HashMapSourceDescriptor<K, V, A: Allocator> {
+    table: RawTable<(K, V), A>,
+}
+
+impl<K: Send + Sync, V: Send + Sync, A: Allocator> SourceCleanup
+    for HashMapSourceDescriptor<K, V, A>
+{
+    const NEEDS_CLEANUP: bool = core::mem::needs_drop::<(K, V)>();
+
+    unsafe fn cleanup_item_range(&self, range: core::ops::Range<usize>) {
+        if Self::NEEDS_CLEANUP {
+            debug_assert!(range.start <= range.end);
+            debug_assert!(range.start <= self.len());
+            debug_assert!(range.end <= self.len());
+            for index in range {
+                // SAFETY: TODO
+                let full = unsafe { self.table.is_bucket_full(index) };
+                if full {
+                    // SAFETY: TODO
+                    let bucket = unsafe { self.table.bucket(index) };
+                    // SAFETY: TODO
+                    let key_value = unsafe { bucket.read() };
+                    drop(key_value);
+                }
+            }
+        }
+    }
+}
+
+impl<K: Send + Sync, V: Send + Sync, A: Allocator> SourceDescriptor
+    for HashMapSourceDescriptor<K, V, A>
+{
+    type Item = Option<(K, V)>;
+
+    fn len(&self) -> usize {
+        self.table.buckets()
+    }
+
+    unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        debug_assert!(index < self.len());
+        // SAFETY: TODO
+        let full = unsafe { self.table.is_bucket_full(index) };
+        if full {
+            // SAFETY: TODO
+            let bucket = unsafe { self.table.bucket(index) };
+            // SAFETY: TODO
+            unsafe { Some(bucket.read()) }
+        } else {
+            None
+        }
+    }
+}
+
+impl<K, V, A: Allocator> Drop for HashMapSourceDescriptor<K, V, A> {
+    fn drop(&mut self) {
+        // Paralight already dropped each missing bucket via calls to cleanup_item_range(), so we
+        // can simply mark all buckets as cleared and let the RawTable destructor do the rest.
+        // TODO: Optimize this to simply deallocate without touching the control bytes.
+        self.table.clear_no_drop();
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -229,6 +406,28 @@ mod test {
             .par_iter()
             .with_thread_pool(&mut thread_pool)
             .filter_map(|x| x.map(|y| y.deref()))
+            .sum::<i32>();
+        assert_eq!(sum, 21 * 43);
+    }
+
+    #[test]
+    fn test_set_into_par_iter() {
+        let mut set = HashSet::new();
+        for i in 1..=42 {
+            set.insert(Box::new(i));
+        }
+
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        let sum = set
+            .into_par_iter()
+            .with_thread_pool(&mut thread_pool)
+            .filter_map(|x| x.map(|y| *y))
             .sum::<i32>();
         assert_eq!(sum, 21 * 43);
     }
@@ -275,5 +474,25 @@ mod test {
         for (k, v) in map.iter() {
             assert_eq!(**k * **k, **v);
         }
+    }
+
+    #[test]
+    fn test_map_into_par_iter() {
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Box::new(i * i));
+        }
+
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        map.into_par_iter()
+            .with_thread_pool(&mut thread_pool)
+            .filter_map(|x| x)
+            .for_each(|(k, v)| assert_eq!(*k * *k, *v));
     }
 }

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -1,0 +1,257 @@
+use crate::raw::RawTable;
+use crate::{HashMap, HashSet};
+use paralight::iter::{
+    IntoParallelRefMutSource, IntoParallelRefSource, ParallelSource, SourceCleanup,
+    SourceDescriptor,
+};
+
+impl<'data, T: Sync + 'data> IntoParallelRefSource<'data> for HashSet<T> {
+    type Item = Option<&'data T>;
+    type Source = HashSetRefParallelSource<'data, T>;
+
+    fn par_iter(&'data self) -> Self::Source {
+        HashSetRefParallelSource { hash_set: self }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy"]
+pub struct HashSetRefParallelSource<'data, T> {
+    hash_set: &'data HashSet<T>,
+}
+
+impl<'data, T: Sync> ParallelSource for HashSetRefParallelSource<'data, T> {
+    type Item = Option<&'data T>;
+
+    fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
+        HashSetRefSourceDescriptor {
+            table: &self.hash_set.map.table,
+        }
+    }
+}
+
+struct HashSetRefSourceDescriptor<'data, T: Sync> {
+    table: &'data RawTable<(T, ())>,
+}
+
+impl<T: Sync> SourceCleanup for HashSetRefSourceDescriptor<'_, T> {
+    const NEEDS_CLEANUP: bool = false;
+
+    unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
+        // Nothing to cleanup
+    }
+}
+
+impl<'data, T: Sync> SourceDescriptor for HashSetRefSourceDescriptor<'data, T> {
+    type Item = Option<&'data T>;
+
+    fn len(&self) -> usize {
+        self.table.buckets()
+    }
+
+    unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        // SAFETY: TODO
+        let full = unsafe { self.table.is_bucket_full(index) };
+        if full {
+            // SAFETY: TODO
+            let bucket = unsafe { self.table.bucket(index) };
+            let (t, ()) = unsafe { bucket.as_ref() };
+            Some(t)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'data, K: Sync + 'data, V: Sync + 'data> IntoParallelRefSource<'data> for HashMap<K, V> {
+    type Item = Option<&'data (K, V)>;
+    type Source = HashMapRefParallelSource<'data, K, V>;
+
+    fn par_iter(&'data self) -> Self::Source {
+        HashMapRefParallelSource { hash_map: self }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy"]
+pub struct HashMapRefParallelSource<'data, K, V> {
+    hash_map: &'data HashMap<K, V>,
+}
+
+impl<'data, K: Sync, V: Sync> ParallelSource for HashMapRefParallelSource<'data, K, V> {
+    type Item = Option<&'data (K, V)>;
+
+    fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
+        HashMapRefSourceDescriptor {
+            table: &self.hash_map.table,
+        }
+    }
+}
+
+struct HashMapRefSourceDescriptor<'data, K: Sync, V: Sync> {
+    table: &'data RawTable<(K, V)>,
+}
+
+impl<K: Sync, V: Sync> SourceCleanup for HashMapRefSourceDescriptor<'_, K, V> {
+    const NEEDS_CLEANUP: bool = false;
+
+    unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
+        // Nothing to cleanup
+    }
+}
+
+impl<'data, K: Sync, V: Sync> SourceDescriptor for HashMapRefSourceDescriptor<'data, K, V> {
+    type Item = Option<&'data (K, V)>;
+
+    fn len(&self) -> usize {
+        self.table.buckets()
+    }
+
+    unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        // SAFETY: TODO
+        let full = unsafe { self.table.is_bucket_full(index) };
+        if full {
+            // SAFETY: TODO
+            let bucket = unsafe { self.table.bucket(index) };
+            unsafe { Some(bucket.as_ref()) }
+        } else {
+            None
+        }
+    }
+}
+
+// TODO: Remove Sync requirement on V.
+impl<'data, K: Sync + 'data, V: Send + Sync + 'data> IntoParallelRefMutSource<'data>
+    for HashMap<K, V>
+{
+    type Item = Option<(&'data K, &'data mut V)>;
+    type Source = HashMapRefMutParallelSource<'data, K, V>;
+
+    fn par_iter_mut(&'data mut self) -> Self::Source {
+        HashMapRefMutParallelSource { hash_map: self }
+    }
+}
+
+#[must_use = "iterator adaptors are lazy"]
+pub struct HashMapRefMutParallelSource<'data, K, V> {
+    hash_map: &'data mut HashMap<K, V>,
+}
+
+impl<'data, K: Sync, V: Send + Sync> ParallelSource for HashMapRefMutParallelSource<'data, K, V> {
+    type Item = Option<(&'data K, &'data mut V)>;
+
+    fn descriptor(self) -> impl SourceDescriptor<Item = Self::Item> + Sync {
+        HashMapRefMutSourceDescriptor {
+            table: &self.hash_map.table,
+        }
+    }
+}
+
+struct HashMapRefMutSourceDescriptor<'data, K: Sync, V: Send + Sync> {
+    table: &'data RawTable<(K, V)>,
+}
+
+impl<K: Sync, V: Send + Sync> SourceCleanup for HashMapRefMutSourceDescriptor<'_, K, V> {
+    const NEEDS_CLEANUP: bool = false;
+
+    unsafe fn cleanup_item_range(&self, _range: core::ops::Range<usize>) {
+        // Nothing to cleanup
+    }
+}
+
+impl<'data, K: Sync, V: Send + Sync> SourceDescriptor
+    for HashMapRefMutSourceDescriptor<'data, K, V>
+{
+    type Item = Option<(&'data K, &'data mut V)>;
+
+    fn len(&self) -> usize {
+        self.table.buckets()
+    }
+
+    unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        // SAFETY: TODO
+        let full = unsafe { self.table.is_bucket_full(index) };
+        if full {
+            // SAFETY: TODO
+            let bucket = unsafe { self.table.bucket(index) };
+            // SAFETY: TODO
+            let (key, value) = unsafe { bucket.as_mut() };
+            Some((key, value))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::boxed::Box;
+    use core::ops::Deref;
+    use paralight::iter::{ParallelIteratorExt, ParallelSourceExt};
+    use paralight::{CpuPinningPolicy, RangeStrategy, ThreadCount, ThreadPoolBuilder};
+
+    #[test]
+    fn test_set_par_iter() {
+        let mut set = HashSet::new();
+        for i in 1..=42 {
+            set.insert(Box::new(i));
+        }
+
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        let sum = set
+            .par_iter()
+            .with_thread_pool(&mut thread_pool)
+            .filter_map(|x| x.map(|y| y.deref()))
+            .sum::<i32>();
+        assert_eq!(sum, 21 * 43);
+    }
+
+    #[test]
+    fn test_map_par_iter() {
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Box::new(i * i));
+        }
+
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        map.par_iter()
+            .with_thread_pool(&mut thread_pool)
+            .filter_map(|x| x)
+            .for_each(|(k, v)| assert_eq!(**k * **k, **v));
+    }
+
+    #[test]
+    fn test_map_par_iter_mut() {
+        let mut map = HashMap::new();
+        for i in 1..=42 {
+            map.insert(Box::new(i), Box::new(i));
+        }
+
+        let mut thread_pool = ThreadPoolBuilder {
+            num_threads: ThreadCount::AvailableParallelism,
+            range_strategy: RangeStrategy::WorkStealing,
+            cpu_pinning: CpuPinningPolicy::No,
+        }
+        .build();
+
+        map.par_iter_mut()
+            .with_thread_pool(&mut thread_pool)
+            .filter_map(|x| x)
+            .for_each(|(k, v)| **v *= **k);
+
+        for (k, v) in map.iter() {
+            assert_eq!(**k * **k, **v);
+        }
+    }
+}

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -54,11 +54,13 @@ impl<'data, T: Sync, A: Allocator> SourceDescriptor for HashSetRefSourceDescript
     }
 
     unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        debug_assert!(index < self.len());
         // SAFETY: TODO
         let full = unsafe { self.table.is_bucket_full(index) };
         if full {
             // SAFETY: TODO
             let bucket = unsafe { self.table.bucket(index) };
+            // SAFETY: TODO
             let (t, ()) = unsafe { bucket.as_ref() };
             Some(t)
         } else {
@@ -118,11 +120,13 @@ impl<'data, K: Sync, V: Sync, A: Allocator> SourceDescriptor
     }
 
     unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        debug_assert!(index < self.len());
         // SAFETY: TODO
         let full = unsafe { self.table.is_bucket_full(index) };
         if full {
             // SAFETY: TODO
             let bucket = unsafe { self.table.bucket(index) };
+            // SAFETY: TODO
             unsafe { Some(bucket.as_ref()) }
         } else {
             None
@@ -184,6 +188,7 @@ impl<'data, K: Sync, V: Send + Sync, A: Allocator> SourceDescriptor
     }
 
     unsafe fn fetch_item(&self, index: usize) -> Self::Item {
+        debug_assert!(index < self.len());
         // SAFETY: TODO
         let full = unsafe { self.table.is_bucket_full(index) };
         if full {

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -8,7 +8,7 @@ use crate::raw::Allocator;
 use crate::{HashMap, HashSet};
 use paralight::iter::{
     IntoParallelRefMutSource, IntoParallelRefSource, IntoParallelSource, ParallelSource,
-    SourceCleanup, SourceDescriptor,
+    SimpleSourceDescriptor, SourceCleanup, SourceDescriptor,
 };
 
 // HashSet.par_iter()
@@ -56,10 +56,12 @@ impl<T: Sync, A: Allocator> SourceCleanup for HashSetRefSourceDescriptor<'_, T, 
     }
 }
 
-impl<'data, T: Sync, A: Allocator> SourceDescriptor for HashSetRefSourceDescriptor<'data, T, A> {
+impl<'data, T: Sync, A: Allocator> SimpleSourceDescriptor
+    for HashSetRefSourceDescriptor<'data, T, A>
+{
     type Item = &'data T;
 
-    unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
+    unsafe fn simple_fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: The passed index is less than the number of buckets. This is
         // ensured by the safety preconditions of `fetch_item()`, given that
@@ -129,12 +131,12 @@ impl<K: Sync, V: Sync, A: Allocator> SourceCleanup for HashMapRefSourceDescripto
     }
 }
 
-impl<'data, K: Sync, V: Sync, A: Allocator> SourceDescriptor
+impl<'data, K: Sync, V: Sync, A: Allocator> SimpleSourceDescriptor
     for HashMapRefSourceDescriptor<'data, K, V, A>
 {
     type Item = &'data (K, V);
 
-    unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
+    unsafe fn simple_fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: The passed index is less than the number of buckets. This is
         // ensured by the safety preconditions of `fetch_item()`, given that
@@ -203,12 +205,12 @@ impl<K: Sync, V: Send, A: Allocator> SourceCleanup for HashMapRefMutSourceDescri
     }
 }
 
-impl<'data, K: Sync, V: Send, A: Allocator> SourceDescriptor
+impl<'data, K: Sync, V: Send, A: Allocator> SimpleSourceDescriptor
     for HashMapRefMutSourceDescriptor<'data, K, V, A>
 {
     type Item = (&'data K, &'data mut V);
 
-    unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
+    unsafe fn simple_fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: The passed index is less than the number of buckets. This is
         // ensured by the safety preconditions of `fetch_item()`, given that
@@ -310,10 +312,10 @@ impl<T: Send, A: Allocator> SourceCleanup for HashSetSourceDescriptor<T, A> {
     }
 }
 
-impl<T: Send, A: Allocator> SourceDescriptor for HashSetSourceDescriptor<T, A> {
+impl<T: Send, A: Allocator> SimpleSourceDescriptor for HashSetSourceDescriptor<T, A> {
     type Item = T;
 
-    unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
+    unsafe fn simple_fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: The passed index is less than the number of buckets. This is
         // ensured by the safety preconditions of `fetch_item()`, given that
@@ -428,10 +430,10 @@ impl<K: Send, V: Send, A: Allocator> SourceCleanup for HashMapSourceDescriptor<K
     }
 }
 
-impl<K: Send, V: Send, A: Allocator> SourceDescriptor for HashMapSourceDescriptor<K, V, A> {
+impl<K: Send, V: Send, A: Allocator> SimpleSourceDescriptor for HashMapSourceDescriptor<K, V, A> {
     type Item = (K, V);
 
-    unsafe fn fetch_item(&self, index: usize) -> Option<Self::Item> {
+    unsafe fn simple_fetch_item(&self, index: usize) -> Option<Self::Item> {
         debug_assert!(index < self.len());
         // SAFETY: The passed index is less than the number of buckets. This is
         // ensured by the safety preconditions of `fetch_item()`, given that

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -1,3 +1,9 @@
+#![forbid(
+    unsafe_op_in_unsafe_fn,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::undocumented_unsafe_blocks
+)]
+
 use crate::raw::Allocator;
 use crate::{HashMap, HashSet};
 use paralight::iter::{

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -592,7 +592,7 @@ mod test {
 
     impl<T: Copy + Hash> Hash for HashCell<T> {
         fn hash<H: Hasher>(&self, state: &mut H) {
-            self.0.get().hash(state)
+            self.0.get().hash(state);
         }
     }
 

--- a/src/external_trait_impls/paralight.rs
+++ b/src/external_trait_impls/paralight.rs
@@ -8,7 +8,7 @@ use crate::alloc::Allocator;
 use crate::{HashMap, HashSet};
 use paralight::iter::{
     IntoParallelRefMutSource, IntoParallelRefSource, IntoParallelSource, ParallelSource,
-    SimpleSourceDescriptor, SourceCleanup, SourceDescriptor,
+    RewindableSource, SimpleSourceDescriptor, SourceCleanup, SourceDescriptor,
 };
 
 // HashSet.par_iter()
@@ -26,6 +26,15 @@ impl<'data, T: Sync + 'data, S: 'data, A: Allocator + 'data> IntoParallelRefSour
 #[must_use = "iterator adaptors are lazy"]
 pub struct HashSetRefParallelSource<'data, T, S, A: Allocator> {
     hash_set: &'data HashSet<T, S, A>,
+}
+
+// SAFETY:
+// - it is safe to fetch a reference to any item an unlimited number of times
+//   and concurrently,
+// - the source doesn't need cleanup.
+unsafe impl<'data, T, S, A: Allocator> RewindableSource
+    for HashSetRefParallelSource<'data, T, S, A>
+{
 }
 
 impl<'data, T: Sync, S, A: Allocator> ParallelSource for HashSetRefParallelSource<'data, T, S, A> {
@@ -99,6 +108,15 @@ impl<'data, K: Sync + 'data, V: Sync + 'data, S: 'data, A: Allocator + 'data>
 #[must_use = "iterator adaptors are lazy"]
 pub struct HashMapRefParallelSource<'data, K, V, S, A: Allocator> {
     hash_map: &'data HashMap<K, V, S, A>,
+}
+
+// SAFETY:
+// - it is safe to fetch a reference to any (key, value) pair an unlimited
+//   number of times and concurrently,
+// - the source doesn't need cleanup.
+unsafe impl<'data, K, V, S, A: Allocator> RewindableSource
+    for HashMapRefParallelSource<'data, K, V, S, A>
+{
 }
 
 impl<'data, K: Sync, V: Sync, S, A: Allocator> ParallelSource

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1467,6 +1467,34 @@ impl<T, A: Allocator> RawTable<T, A> {
         mem::forget(self);
         alloc
     }
+
+    /// Deallocates the table without dropping any element.
+    ///
+    /// # Safety
+    ///
+    /// It's the responsibility of the caller to ensure that all elements
+    /// have been separately read and dropped. However, the caller doesn't
+    /// need to clear the control bytes beforehand.
+    #[cfg(feature = "paralight")]
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub(crate) unsafe fn deallocate_cleared_table(&mut self) {
+        if self.table.is_empty_singleton() {
+            return;
+        }
+
+        // Avoid `Option::unwrap_or_else` because it bloats LLVM IR.
+        let (layout, ctrl_offset) =
+            match Self::TABLE_LAYOUT.calculate_layout_for(self.table.buckets()) {
+                Some(lco) => lco,
+                None => unsafe { hint::unreachable_unchecked() },
+            };
+        let ptr =
+            unsafe { NonNull::new_unchecked(self.table.ctrl.as_ptr().sub(ctrl_offset).cast()) };
+        self.alloc.deallocate(ptr, layout);
+
+        // Reset the table, so that it can be dropped without double free.
+        self.table = RawTableInner::NEW;
+    }
 }
 
 unsafe impl<T, A: Allocator> Send for RawTable<T, A>

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1482,12 +1482,10 @@ impl<T, A: Allocator> RawTable<T, A> {
             return;
         }
 
-        // Avoid `Option::unwrap_or_else` because it bloats LLVM IR.
-        let (layout, ctrl_offset) =
-            match Self::TABLE_LAYOUT.calculate_layout_for(self.table.num_buckets()) {
-                Some(lco) => lco,
-                None => unsafe { hint::unreachable_unchecked() },
-            };
+        let (layout, ctrl_offset) = {
+            let option = Self::TABLE_LAYOUT.calculate_layout_for(self.table.num_buckets());
+            unsafe { option.unwrap_unchecked() }
+        };
         let ptr =
             unsafe { NonNull::new_unchecked(self.table.ctrl.as_ptr().sub(ctrl_offset).cast()) };
         unsafe {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1484,13 +1484,15 @@ impl<T, A: Allocator> RawTable<T, A> {
 
         // Avoid `Option::unwrap_or_else` because it bloats LLVM IR.
         let (layout, ctrl_offset) =
-            match Self::TABLE_LAYOUT.calculate_layout_for(self.table.buckets()) {
+            match Self::TABLE_LAYOUT.calculate_layout_for(self.table.num_buckets()) {
                 Some(lco) => lco,
                 None => unsafe { hint::unreachable_unchecked() },
             };
         let ptr =
             unsafe { NonNull::new_unchecked(self.table.ctrl.as_ptr().sub(ctrl_offset).cast()) };
-        self.alloc.deallocate(ptr, layout);
+        unsafe {
+            self.alloc.deallocate(ptr, layout);
+        }
 
         // Reset the table, so that it can be dropped without double free.
         self.table = RawTableInner::NEW;


### PR DESCRIPTION
[Paralight](https://github.com/gendx/paralight) is a lightweight parallelism library tuned for indexed structures such as slices. Given that the internal representation of hashbrown's hash tables is a slice of buckets (that each optionally contain a value), it's a good fit to integrate with (https://github.com/gendx/paralight/issues/5).

This pull request is here to iterate on the design. As the integration needs access to the raw hash table representation, it's done here in the hashbrown crate (similarly to Rayon's integration).