### PR TITLE
refactor: Remove `InsertSlot`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1840,11 +1840,11 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         let hash = make_hash::<K, S>(&self.hash_builder, &k);
-        match self.find_or_find_insert_slot(hash, &k) {
+        match self.find_or_find_insert_index(hash, &k) {
             Ok(bucket) => Some(mem::replace(unsafe { &mut bucket.as_mut().1 }, v)),
-            Err(slot) => {
+            Err(index) => {
                 unsafe {
-                    self.table.insert_in_slot(hash, slot, (k, v));
+                    self.table.insert_at_index(hash, index, (k, v));
                 }
                 None
             }
@@ -1852,15 +1852,15 @@ where
     }
 
     #[cfg_attr(feature = "inline-more", inline)]
-    pub(crate) fn find_or_find_insert_slot<Q>(
+    pub(crate) fn find_or_find_insert_index<Q>(
         &mut self,
         hash: u64,
         key: &Q,
-    ) -> Result<Bucket<(K, V)>, crate::raw::InsertSlot>
+    ) -> Result<Bucket<(K, V)>, usize>
     where
         Q: Equivalent<K> + ?Sized,
     {
-        self.table.find_or_find_insert_slot(
+        self.table.find_or_find_insert_index(
             hash,
             equivalent_key(key),
             make_hasher(&self.hash_builder),

--- a/src/set.rs
+++ b/src/set.rs
@@ -913,9 +913,9 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_or_insert(&mut self, value: T) -> &T {
         let hash = make_hash(&self.map.hash_builder, &value);
-        let bucket = match self.map.find_or_find_insert_slot(hash, &value) {
+        let bucket = match self.map.find_or_find_insert_index(hash, &value) {
             Ok(bucket) => bucket,
-            Err(slot) => unsafe { self.map.table.insert_in_slot(hash, slot, (value, ())) },
+            Err(index) => unsafe { self.map.table.insert_at_index(hash, index, (value, ())) },
         };
         unsafe { &bucket.as_ref().0 }
     }
@@ -952,12 +952,12 @@ where
         F: FnOnce(&Q) -> T,
     {
         let hash = make_hash(&self.map.hash_builder, value);
-        let bucket = match self.map.find_or_find_insert_slot(hash, value) {
+        let bucket = match self.map.find_or_find_insert_index(hash, value) {
             Ok(bucket) => bucket,
-            Err(slot) => {
+            Err(index) => {
                 let new = f(value);
                 assert!(value.equivalent(&new), "new value is not equivalent");
-                unsafe { self.map.table.insert_in_slot(hash, slot, (new, ())) }
+                unsafe { self.map.table.insert_at_index(hash, index, (new, ())) }
             }
         };
         unsafe { &bucket.as_ref().0 }
@@ -1139,11 +1139,11 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace(&mut self, value: T) -> Option<T> {
         let hash = make_hash(&self.map.hash_builder, &value);
-        match self.map.find_or_find_insert_slot(hash, &value) {
+        match self.map.find_or_find_insert_index(hash, &value) {
             Ok(bucket) => Some(mem::replace(unsafe { &mut bucket.as_mut().0 }, value)),
-            Err(slot) => {
+            Err(index) => {
                 unsafe {
-                    self.map.table.insert_in_slot(hash, slot, (value, ()));
+                    self.map.table.insert_at_index(hash, index, (value, ()));
                 }
                 None
             }
@@ -1586,14 +1586,14 @@ where
     fn bitxor_assign(&mut self, rhs: &HashSet<T, S, A>) {
         for item in rhs {
             let hash = make_hash(&self.map.hash_builder, item);
-            match self.map.find_or_find_insert_slot(hash, item) {
+            match self.map.find_or_find_insert_index(hash, item) {
                 Ok(bucket) => unsafe {
                     self.map.table.remove(bucket);
                 },
-                Err(slot) => unsafe {
+                Err(index) => unsafe {
                     self.map
                         .table
-                        .insert_in_slot(hash, slot, (item.clone(), ()));
+                        .insert_at_index(hash, index, (item.clone(), ()));
                 },
             }
         }


### PR DESCRIPTION
Finally getting back to cleaning up the raw table API, and this is one of the things I wanted to do properly.

Essentially, while `InsertSlot` is *moderately* useful to ensure that indices are used correctly, it doesn't really hold its weight as an API and also is a bit misleading: it doesn't actually contain the insertion slot (i.e. pointer), just an index to it. So, this removes the `InsertSlot` type and renames the relevant APIs to refer to an "insert index" instead of an "insert slot."

I mostly hastily searched for the word "slot" to reword comments as necessary, although the term "slot" to refer to an actual position in the HashTable should be unchanged. To be clear, the goal of this change is to have "slot" mean the physical location in the table, and "index" refer to the specific index to obtain that location, given a table.

----

Note that a future addition is to also remove the `Bucket` type, replacing it with `usize`, `*mut T`, or `&mut MaybeUninit<T>` where appropriate. However, I wanted to avoid stacking too many changes at once, so, this just starts with `InsertSlot`.