### PR TITLE
Fix README doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ rand = { version = "0.9.0", features = ["small_rng"] }
 rayon = "1.2"
 fnv = "1.0.7"
 serde_test = "1.0"
-doc-comment = "0.3.1"
 bumpalo = { version = "3.13.0", features = ["allocator-api2"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,9 @@ extern crate std;
 #[cfg_attr(feature = "rustc-dep-of-std", allow(unused_extern_crates))]
 extern crate alloc;
 
-#[cfg(feature = "nightly")]
+#[doc = include_str!("../README.md")]
 #[cfg(doctest)]
-doc_comment::doctest!("../README.md");
+pub struct ReadmeDoctests;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Using the solution described in the [official documentation](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html) instead of relying on a third-party crate.