### PR TITLE
do not specialise on `Copy`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
         core_intrinsics,
         dropck_eyepatch,
         min_specialization,
+        trivial_clone,
         extend_one,
         allocator_api,
         slice_ptr_get,

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3330,7 +3330,7 @@ impl<T: Clone, A: Allocator + Clone> RawTableClone for RawTable<T, A> {
     }
 }
 #[cfg(feature = "nightly")]
-impl<T: Copy, A: Allocator + Clone> RawTableClone for RawTable<T, A> {
+impl<T: core::clone::TrivialClone, A: Allocator + Clone> RawTableClone for RawTable<T, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn clone_from_spec(&mut self, source: &Self) {
         source


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/135634 started the process of removing the `#[rustc_unsafe_specialization_marker]` on `Copy` in favour of a newly added trait `TrivialClone` that allows sound specialisation by virtue of only being implemented if the `Clone` implementation is always equivalent to a copy. However, removing the attribute entirely was not possible in https://github.com/rust-lang/rust/pull/135634 as `hashbrown` contains a `Copy` specialisation. Thus, this PR removes the relevant specialisation from `hashbrown` and switches it to specialise on `TrivialClone` instead.