### PR TITLE
WIP: Replacing `RawTable` with `HashTable` internally

### DIFF
--- a/src/external_trait_impls/rayon/map.rs
+++ b/src/external_trait_impls/rayon/map.rs
@@ -288,7 +288,7 @@ impl<K: Sync, V: Sync, S, A: Allocator> HashMap<K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn par_keys(&self) -> ParKeys<'_, K, V> {
         ParKeys {
-            inner: unsafe { self.table.par_iter() },
+            inner: unsafe { self.table.raw.par_iter() },
             marker: PhantomData,
         }
     }
@@ -297,7 +297,7 @@ impl<K: Sync, V: Sync, S, A: Allocator> HashMap<K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn par_values(&self) -> ParValues<'_, K, V> {
         ParValues {
-            inner: unsafe { self.table.par_iter() },
+            inner: unsafe { self.table.raw.par_iter() },
             marker: PhantomData,
         }
     }
@@ -308,7 +308,7 @@ impl<K: Send, V: Send, S, A: Allocator> HashMap<K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn par_values_mut(&mut self) -> ParValuesMut<'_, K, V> {
         ParValuesMut {
-            inner: unsafe { self.table.par_iter() },
+            inner: unsafe { self.table.raw.par_iter() },
             marker: PhantomData,
         }
     }
@@ -318,7 +318,7 @@ impl<K: Send, V: Send, S, A: Allocator> HashMap<K, V, S, A> {
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn par_drain(&mut self) -> ParDrain<'_, K, V, A> {
         ParDrain {
-            inner: self.table.par_drain(),
+            inner: self.table.raw.par_drain(),
         }
     }
 }
@@ -349,7 +349,7 @@ impl<K: Send, V: Send, S, A: Allocator + Send> IntoParallelIterator for HashMap<
     #[cfg_attr(feature = "inline-more", inline)]
     fn into_par_iter(self) -> Self::Iter {
         IntoParIter {
-            inner: self.table.into_par_iter(),
+            inner: self.table.raw.into_par_iter(),
         }
     }
 }
@@ -361,7 +361,7 @@ impl<'a, K: Sync, V: Sync, S, A: Allocator> IntoParallelIterator for &'a HashMap
     #[cfg_attr(feature = "inline-more", inline)]
     fn into_par_iter(self) -> Self::Iter {
         ParIter {
-            inner: unsafe { self.table.par_iter() },
+            inner: unsafe { self.table.raw.par_iter() },
             marker: PhantomData,
         }
     }
@@ -374,7 +374,7 @@ impl<'a, K: Sync, V: Send, S, A: Allocator> IntoParallelIterator for &'a mut Has
     #[cfg_attr(feature = "inline-more", inline)]
     fn into_par_iter(self) -> Self::Iter {
         ParIterMut {
-            inner: unsafe { self.table.par_iter() },
+            inner: unsafe { self.table.raw.par_iter() },
             marker: PhantomData,
         }
     }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1059,19 +1059,6 @@ impl<T, A: Allocator> RawTable<T, A> {
         }
     }
 
-    /// Inserts a new element into the table, and returns a mutable reference to it.
-    ///
-    /// This does not check if the given element already exists in the table.
-    #[cfg_attr(feature = "inline-more", inline)]
-    pub(crate) fn insert_entry(
-        &mut self,
-        hash: u64,
-        value: T,
-        hasher: impl Fn(&T) -> u64,
-    ) -> &mut T {
-        unsafe { self.insert(hash, value, hasher).as_mut() }
-    }
-
     /// Inserts a new element into the table, without growing the table.
     ///
     /// There must be enough space in the table to insert the new element.

--- a/src/raw_entry.rs
+++ b/src/raw_entry.rs
@@ -593,14 +593,14 @@ impl<'a, K, V, S, A: Allocator> RawEntryBuilderMut<'a, K, V, S, A> {
     where
         for<'b> F: FnMut(&'b K) -> bool,
     {
-        match self.map.table.find(hash, |(k, _)| is_match(k)) {
+        match self.map.table.raw.find(hash, |(k, _)| is_match(k)) {
             Some(elem) => RawEntryMut::Occupied(RawOccupiedEntryMut {
                 elem,
-                table: &mut self.map.table,
+                table: &mut self.map.table.raw,
                 hash_builder: &self.map.hash_builder,
             }),
             None => RawEntryMut::Vacant(RawVacantEntryMut {
-                table: &mut self.map.table,
+                table: &mut self.map.table.raw,
                 hash_builder: &self.map.hash_builder,
             }),
         }
@@ -662,7 +662,7 @@ impl<'a, K, V, S, A: Allocator> RawEntryBuilder<'a, K, V, S, A> {
     where
         F: FnMut(&K) -> bool,
     {
-        match self.map.table.get(hash, |(k, _)| is_match(k)) {
+        match self.map.table.raw.get(hash, |(k, _)| is_match(k)) {
             Some((key, value)) => Some((key, value)),
             None => None,
         }

--- a/src/raw_entry.rs
+++ b/src/raw_entry.rs
@@ -1354,11 +1354,15 @@ impl<'a, K, V, S, A: Allocator> RawVacantEntryMut<'a, K, V, S, A> {
         K: Hash,
         S: BuildHasher,
     {
-        let &mut (ref mut k, ref mut v) = self.table.insert_entry(
-            hash,
-            (key, value),
-            make_hasher::<_, V, S>(self.hash_builder),
-        );
+        let &mut (ref mut k, ref mut v) = unsafe {
+            self.table
+                .insert(
+                    hash,
+                    (key, value),
+                    make_hasher::<_, V, S>(self.hash_builder),
+                )
+                .as_mut()
+        };
         (k, v)
     }
 
@@ -1409,9 +1413,11 @@ impl<'a, K, V, S, A: Allocator> RawVacantEntryMut<'a, K, V, S, A> {
     where
         H: Fn(&K) -> u64,
     {
-        let &mut (ref mut k, ref mut v) = self
-            .table
-            .insert_entry(hash, (key, value), |x| hasher(&x.0));
+        let &mut (ref mut k, ref mut v) = unsafe {
+            self.table
+                .insert(hash, (key, value), |x| hasher(&x.0))
+                .as_mut()
+        };
         (k, v)
     }
 

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -34,10 +34,10 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn rustc_entry(&mut self, key: K) -> RustcEntry<'_, K, V, A> {
         let hash = make_hash(&self.hash_builder, &key);
-        if let Some(elem) = self.table.find(hash, |q| q.0.eq(&key)) {
+        if let Some(elem) = self.table.raw.find(hash, |q| q.0.eq(&key)) {
             RustcEntry::Occupied(RustcOccupiedEntry {
                 elem,
-                table: &mut self.table,
+                table: &mut self.table.raw,
             })
         } else {
             // Ideally we would put this in VacantEntry::insert, but Entry is not
@@ -48,7 +48,7 @@ where
             RustcEntry::Vacant(RustcVacantEntry {
                 hash,
                 key,
-                table: &mut self.table,
+                table: &mut self.table.raw,
             })
         }
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -401,8 +401,8 @@ impl<T, S, A: Allocator> HashSet<T, S, A> {
         ExtractIf {
             f,
             inner: RawExtractIf {
-                iter: unsafe { self.map.table.iter() },
-                table: &mut self.map.table,
+                iter: unsafe { self.map.table.raw.iter() },
+                table: &mut self.map.table.raw,
             },
         }
     }

--- a/src/table.rs
+++ b/src/table.rs
@@ -66,6 +66,7 @@ impl<T> HashTable<T, Global> {
     /// assert_eq!(table.len(), 0);
     /// assert_eq!(table.capacity(), 0);
     /// ```
+    #[cfg_attr(feature = "rustc-dep-of-std", rustc_const_stable_indirect)]
     pub const fn new() -> Self {
         Self {
             raw: RawTable::new(),
@@ -133,6 +134,7 @@ where
     /// #     test()
     /// # }
     /// ```
+    #[cfg_attr(feature = "rustc-dep-of-std", rustc_const_stable_indirect)]
     pub const fn new_in(alloc: A) -> Self {
         Self {
             raw: RawTable::new_in(alloc),


### PR DESCRIPTION
This is marked as WIP because this is not finished, both because this probably results in more IR bloat, and because most of the code simply just accesses the `raw` field of the `HashTable` directly.

The goal here is to mostly keep this PR open so that folks can see what is currently possible and what methods are missing, mostly as a demonstration tool and indication of progress.