### PR TITLE
Override `clone_from` for `HashTable`

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -1608,6 +1608,10 @@ where
             raw: self.raw.clone(),
         }
     }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.raw.clone_from(&source.raw);
+    }
 }
 
 impl<T, A> fmt::Debug for HashTable<T, A>


### PR DESCRIPTION
This actually causes some `HashMap` tests to fail otherwise, and thus is required for #666.

However, we probably just want this to be the case anyway.