### PR TITLE
Fix `unreachable_pub` lint

### DIFF
--- a/src/external_trait_impls/rayon/raw.rs
+++ b/src/external_trait_impls/rayon/raw.rs
@@ -10,7 +10,7 @@ use rayon::iter::{
 };
 
 /// Parallel iterator which returns a raw pointer to every full bucket in the table.
-pub struct RawParIter<T> {
+pub(crate) struct RawParIter<T> {
     iter: RawIterRange<T>,
 }
 
@@ -75,7 +75,7 @@ impl<T> UnindexedProducer for ParIterProducer<T> {
 }
 
 /// Parallel iterator which consumes a table and returns elements.
-pub struct RawIntoParIter<T, A: Allocator = Global> {
+pub(crate) struct RawIntoParIter<T, A: Allocator = Global> {
     table: RawTable<T, A>,
 }
 
@@ -108,7 +108,7 @@ impl<T: Send, A: Allocator + Send> ParallelIterator for RawIntoParIter<T, A> {
 }
 
 /// Parallel iterator which consumes elements without freeing the table storage.
-pub struct RawParDrain<'a, T, A: Allocator = Global> {
+pub(crate) struct RawParDrain<'a, T, A: Allocator = Global> {
     // We don't use a &'a mut RawTable<T> because we want RawParDrain to be
     // covariant over T.
     table: NonNull<RawTable<T, A>>,
@@ -206,7 +206,7 @@ impl<T> Drop for ParDrainProducer<T> {
 impl<T, A: Allocator> RawTable<T, A> {
     /// Returns a parallel iterator over the elements in a `RawTable`.
     #[cfg_attr(feature = "inline-more", inline)]
-    pub unsafe fn par_iter(&self) -> RawParIter<T> {
+    pub(crate) unsafe fn par_iter(&self) -> RawParIter<T> {
         RawParIter {
             iter: self.iter().iter,
         }
@@ -214,14 +214,14 @@ impl<T, A: Allocator> RawTable<T, A> {
 
     /// Returns a parallel iterator over the elements in a `RawTable`.
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn into_par_iter(self) -> RawIntoParIter<T, A> {
+    pub(crate) fn into_par_iter(self) -> RawIntoParIter<T, A> {
         RawIntoParIter { table: self }
     }
 
     /// Returns a parallel iterator which consumes all elements of a `RawTable`
     /// without freeing its memory allocation.
     #[cfg_attr(feature = "inline-more", inline)]
-    pub fn par_drain(&mut self) -> RawParDrain<'_, T, A> {
+    pub(crate) fn par_drain(&mut self) -> RawParDrain<'_, T, A> {
         RawParDrain {
             table: NonNull::from(self),
             marker: PhantomData,

--- a/src/raw/alloc.rs
+++ b/src/raw/alloc.rs
@@ -11,7 +11,7 @@ mod inner {
     #[cfg(test)]
     pub use crate::alloc::alloc::AllocError;
     use crate::alloc::alloc::Layout;
-    pub use crate::alloc::alloc::{Allocator, Global};
+    pub(crate) use crate::alloc::alloc::{Allocator, Global};
     use core::ptr::NonNull;
 
     #[allow(clippy::map_err_ignore)]
@@ -34,7 +34,7 @@ mod inner {
     use crate::alloc::alloc::Layout;
     #[cfg(test)]
     pub use allocator_api2::alloc::AllocError;
-    pub use allocator_api2::alloc::{Allocator, Global};
+    pub(crate) use allocator_api2::alloc::{Allocator, Global};
     use core::ptr::NonNull;
 
     #[allow(clippy::map_err_ignore)]

--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -5,7 +5,7 @@ use core::{
     ptr,
 };
 
-pub struct ScopeGuard<T, F>
+pub(crate) struct ScopeGuard<T, F>
 where
     F: FnMut(&mut T),
 {
@@ -14,7 +14,7 @@ where
 }
 
 #[inline]
-pub fn guard<T, F>(value: T, dropfn: F) -> ScopeGuard<T, F>
+pub(crate) fn guard<T, F>(value: T, dropfn: F) -> ScopeGuard<T, F>
 where
     F: FnMut(&mut T),
 {
@@ -26,7 +26,7 @@ where
     F: FnMut(&mut T),
 {
     #[inline]
-    pub fn into_inner(guard: Self) -> T {
+    pub(crate) fn into_inner(guard: Self) -> T {
         // Cannot move out of Drop-implementing types, so
         // ptr::read the value out of a ManuallyDrop<Self>
         // Don't use mem::forget as that might invalidate value


### PR DESCRIPTION
In #669, a method marked `pub` had to be changed to `pub(crate)` in order to satisfy MSRV. Essentially, MSRV is not smart enough to determine that a method marked `pub` which is actually inaccessible outside the crate is not leaking private types, and so, we need to fix this.

I decided to automatically fix all instances of the `unreachable_pub` lint since, although MSRV does not have this lint, it could benefit from this change in the future, and it's better to make the changes now than have to sprinkle them occasionally later. I also see no need to permanently try and catch the lint in CI, since this is only a theoretically useful change. (Also, it has a few false positives, like changing `Bucket` to `pub(crate)` not being allowed due to being present in public trait implementations, despite the type itself not being public.)