### PR TITLE
Improve generated code for NEON

### DIFF
--- a/src/control/group/neon.rs
+++ b/src/control/group/neon.rs
@@ -76,7 +76,10 @@ impl Group {
     /// `EMPTY`.
     #[inline]
     pub(crate) fn match_empty(self) -> BitMask {
-        self.match_tag(Tag::EMPTY)
+        unsafe {
+            let ctrl = neon::vget_lane_u64(neon::vreinterpret_u64_u8(self.0), 0);
+            BitMask(ctrl & (ctrl << 1) & BITMASK_ITER_MASK)
+        }
     }
 
     /// Returns a `BitMask` indicating all tags in the group which are
@@ -84,8 +87,8 @@ impl Group {
     #[inline]
     pub(crate) fn match_empty_or_deleted(self) -> BitMask {
         unsafe {
-            let cmp = neon::vcltz_s8(neon::vreinterpret_s8_u8(self.0));
-            BitMask(neon::vget_lane_u64(neon::vreinterpret_u64_u8(cmp), 0))
+            let ctrl = neon::vget_lane_u64(neon::vreinterpret_u64_u8(self.0), 0);
+            BitMask(ctrl & BITMASK_ITER_MASK)
         }
     }
 
@@ -93,8 +96,8 @@ impl Group {
     #[inline]
     pub(crate) fn match_full(self) -> BitMask {
         unsafe {
-            let cmp = neon::vcgez_s8(neon::vreinterpret_s8_u8(self.0));
-            BitMask(neon::vget_lane_u64(neon::vreinterpret_u64_u8(cmp), 0))
+            let ctrl = neon::vget_lane_u64(neon::vreinterpret_u64_u8(self.0), 0);
+            BitMask(!ctrl & BITMASK_ITER_MASK)
         }
     }
 


### PR DESCRIPTION
Disclaimer: found by Claude

This forces LLVM to change:

```
  cmeq.8b  v2, v2, v0       ; NEON compare with EMPTY
  umaxv.8b b2, v2            ; horizontal vector max (~3-4 cycle latency)
  fmov     w17, s2           ; extract to 32-bit GPR
  tbnz     w17, #0, ...      ; test bit
```

into 

```
  fmov  x17, d1                    ; extract group to 64-bit GPR
  and   x17, x17, x17, lsl #1     ; SWAR: both top bits set = EMPTY
  tst   x17, #0x8080808080808080   ; any empty byte?
```

Effect on various benchmarks 5-15%
