### PR TITLE
Optimize insert probing / rehash_in_place

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1832,6 +1832,24 @@ impl RawTableInner {
             // insertion slot from the group if we don't have one yet.
             if likely(insert_index.is_none()) {
                 insert_index = self.find_insert_index_in_group(&group, &probe_seq);
+
+                // When the found slot is EMPTY (not DELETED), we can stop probing
+                // immediately without computing the more expensive match_empty() on
+                // the whole group. This is the common case when there are no
+                // tombstones in the table.
+                //
+                // An EMPTY slot in this group guarantees the key we're looking for
+                // can't be in a subsequent group. Additionally, a true EMPTY byte
+                // at the computed index means the index is valid (not a small-table
+                // false positive from wrapping), so fix_insert_index is unnecessary.
+                if let Some(idx) = insert_index {
+                    // SAFETY: The index was found by `find_insert_index_in_group` which
+                    // guarantees it is in the range `0..=self.bucket_mask`, so calling
+                    // `self.ctrl(idx)` is safe.
+                    if likely(unsafe { *self.ctrl(idx) } == Tag::EMPTY) {
+                        return Err(idx);
+                    }
+                }
             }
 
             if let Some(insert_index) = insert_index {


### PR DESCRIPTION
Disclaimer: used Claude to look at generated code and provide suggestions (by looking at the generated code, running benchmarks...).


Description (Claude):

find_or_find_insert_index_inner: When the first empty-or-deleted slot found is EMPTY (not a tombstone), return immediately without the expensive match_empty() NEON/SSE group scan. This is the common case when there are no tombstones. An EMPTY byte at the computed index also guarantees the index is valid (no small-table wrapping), so fix_insert_index is skipped too.

Result (Apple M1 CPU):

```
  ┌───────────────────────────┬────────────┬─────────────────────┤
  │ Benchmark (10-run median) │  Baseline  │ Branch.             │
  ├───────────────────────────┼────────────┼─────────────────────┤
  │ insert_foldhash_serial    │ 11,734 ns  │ 11,410 ns (-2.8%)   │ 
  ├───────────────────────────┼────────────┼─────────────────────┤
  │ rehash_in_place           │ 220,745 ns │ 189,163 ns (-14.3%) │
  └───────────────────────────┴────────────┴─────────────────────┤
                                                                                                                                                                               
```


One thing I noticed is that the tables in the benchmarks are quite small, so any prefetching or other optimizations will not have any effect on them.