### PR TITLE
lsx: use immediate form of vslti for zero comparison

### DIFF
--- a/src/control/group/lsx.rs
+++ b/src/control/group/lsx.rs
@@ -117,8 +117,7 @@ impl Group {
         //   1111_1111 | 1000_0000 = 1111_1111
         //   0000_0000 | 1000_0000 = 1000_0000
         unsafe {
-            let zero = lsx_vreplgr2vr_b(0);
-            let special = lsx_vslt_b(self.0, zero);
+            let special = lsx_vslti_b::<0>(self.0);
             Group(lsx_vor_v(special, lsx_vreplgr2vr_b(Tag::DELETED.0 as i32)))
         }
     }


### PR DESCRIPTION
Replace the sequence that materializes a zero vector and performs `lsx_vslt_b` with the immediate variant `lsx_vslti_b::<0>`.