### PR TITLE
lsx: use immediate form of vori for DELETED tag mask

### DIFF
--- a/src/control/group/lsx.rs
+++ b/src/control/group/lsx.rs
@@ -118,7 +118,7 @@ impl Group {
         //   0000_0000 | 1000_0000 = 1000_0000
         unsafe {
             let special = lsx_vslti_b::<0>(self.0);
-            Group(lsx_vor_v(special, lsx_vreplgr2vr_b(Tag::DELETED.0 as i32)))
+            Group(lsx_vori_b::<{ Tag::DELETED.0 as u32 }>(special))
         }
     }
 }


### PR DESCRIPTION
Replace `lsx_vor_v` with `lsx_vori_b` to apply the DELETED tag mask using the immediate form instead of materializing a vector constant.