### PR TITLE
Remove package.authors field from Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hashbrown"
 version = "0.17.0"
-authors = ["Amanieu d'Antras <amanieu@gmail.com>"]
 description = "A Rust port of Google's SwissTable hash map"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/hashbrown"


### PR DESCRIPTION
The `package.authors` field has been deprecated since https://github.com/rust-lang/cargo/pull/15068.