### PR TITLE
Use core for Layout instead of alloc

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -8,10 +8,10 @@ pub(crate) use self::inner::{Allocator, Global, do_alloc};
 // This is used when building for `std`.
 #[cfg(feature = "nightly")]
 mod inner {
+    use core::alloc::Layout;
     use core::ptr::NonNull;
     #[cfg(test)]
     pub(crate) use stdalloc::alloc::AllocError;
-    use stdalloc::alloc::Layout;
     pub(crate) use stdalloc::alloc::{Allocator, Global};
 
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<[u8]>, ()> {
@@ -33,8 +33,8 @@ mod inner {
     #[cfg(test)]
     pub(crate) use allocator_api2::alloc::AllocError;
     pub(crate) use allocator_api2::alloc::{Allocator, Global};
+    use core::alloc::Layout;
     use core::ptr::NonNull;
-    use stdalloc::alloc::Layout;
 
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<[u8]>, ()> {
         match alloc.allocate(layout) {
@@ -54,8 +54,9 @@ mod inner {
 // or `nightly` without disturbing users that don't want to use it.
 #[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
 mod inner {
+    use core::alloc::Layout;
     use core::ptr::NonNull;
-    use stdalloc::alloc::{Layout, alloc, dealloc};
+    use stdalloc::alloc::{alloc, dealloc};
 
     #[expect(clippy::missing_safety_doc)] // not exposed outside of this crate
     pub unsafe trait Allocator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub enum TryReserveError {
     /// The memory allocator returned an error
     AllocError {
         /// The layout of the allocation request that failed.
-        layout: stdalloc::alloc::Layout,
+        layout: core::alloc::Layout,
     },
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -2,6 +2,7 @@ use crate::TryReserveError;
 use crate::control::{BitMaskIter, Group, Tag, TagSliceExt};
 use crate::scopeguard::{ScopeGuard, guard};
 use crate::util::{invalid_mut, likely, unlikely};
+use core::alloc::Layout;
 use core::array;
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
@@ -9,7 +10,7 @@ use core::mem;
 use core::ptr;
 use core::ptr::NonNull;
 use core::slice;
-use stdalloc::alloc::{Layout, handle_alloc_error};
+use stdalloc::alloc::handle_alloc_error;
 
 #[cfg(test)]
 use crate::alloc::AllocError;


### PR DESCRIPTION
Extremely minor changes as I'm looking into not depending on alloc again.