### PR TITLE
Fake `ToOwned` trait

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -2,6 +2,22 @@
 pub(crate) use self::inner::AllocError;
 pub(crate) use self::inner::{Allocator, Global, do_alloc};
 
+// Since `ToOwned` is defined in `alloc`, this would prevent us from using
+// this crate in `alloc`; that would be a circular dependency. To get around
+// this particular restriction for `ToOwned`, we just make our own `ToOwned`
+// trait here that `alloc` can blanket-forward to its own definition of
+// `ToOwned` instead.
+#[cfg(feature = "rustc-dep-of-std")]
+#[expect(missing_docs)]
+pub trait ToOwned {
+    type Owned: core::borrow::Borrow<Self>;
+    fn to_owned(&self) -> Self::Owned;
+}
+
+// In every other case, we just use the regular `ToOwned`.
+#[cfg(not(feature = "rustc-dep-of-std"))]
+pub(crate) use stdalloc::borrow::ToOwned;
+
 // Nightly-case.
 // Use unstable `allocator_api` feature.
 // This is compatible with `allocator-api2` which can be enabled or not.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,9 @@ pub use crate::hasher::DefaultHashBuilder;
 #[cfg(feature = "default-hasher")]
 pub use crate::hasher::DefaultHasher;
 
+#[cfg(feature = "rustc-dep-of-std")]
+pub use crate::alloc::ToOwned;
+
 pub mod hash_map {
     //! A hash map implemented with quadratic probing and SIMD lookup.
     pub use crate::map::*;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,3 +1,4 @@
+use crate::alloc::ToOwned;
 use crate::alloc::{Allocator, Global};
 use crate::raw::{Bucket, RawDrain, RawExtractIf, RawIntoIter, RawIter, RawTable};
 use crate::{DefaultHashBuilder, Equivalent, TryReserveError};
@@ -8,7 +9,6 @@ use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::Index;
-use stdalloc::borrow::ToOwned;
 
 #[cfg(feature = "raw-entry")]
 pub use crate::raw_entry::*;
@@ -5073,12 +5073,11 @@ mod test_map {
     use super::Entry::{Occupied, Vacant};
     use super::EntryRef;
     use super::HashMap;
-    use crate::alloc::{AllocError, Allocator, Global};
+    use crate::alloc::{AllocError, Allocator, Global, ToOwned};
     use core::alloc::Layout;
     use core::ptr::NonNull;
     use core::sync::atomic::{AtomicI8, Ordering};
     use rand::{Rng, SeedableRng, rngs::SmallRng};
-    use std::borrow::ToOwned;
     use std::cell::RefCell;
     use std::vec::Vec;
     use stdalloc::string::String;

--- a/src/set.rs
+++ b/src/set.rs
@@ -1574,7 +1574,13 @@ where
                     entry.remove();
                 }
                 map::EntryRef::Vacant(entry) => {
-                    entry.insert(());
+                    // SAFETY: We know that `item.clone()` is equivalent to `item`.
+                    //
+                    // This is *required* to get around the lack of *any* impl
+                    // for `ToOwned` when compiling as `rustc-dep-of-std`.
+                    unsafe {
+                        entry.insert_with_key_unchecked(item.clone(), ());
+                    }
                 }
             }
         }


### PR DESCRIPTION
This follows one of the suggestions for removing the `alloc` dependency, specifically to allow moving `HashMap` into `alloc`: essentially, if we don't have `ToOwned`, store-bought is fine.

The expectation here is that specifically for libstd, they can implement a blanket forwarding of the actual `ToOwned` to this trait and it should work as expected. This is fine by coherence rules even though the coherence rules kind of don't make any more sense once you *are* libstd.

Not 100% sure if this should be merged immediately, since I want to make sure that we actually can get a full alloc-less version of hashbrown working first. But the implementation seems relatively straightforward.