### PR TITLE
Use wrapping arithmetic in ProbeSeq::move_next to avoid overflow

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -87,9 +87,8 @@ impl ProbeSeq {
             "Went past end of probe sequence"
         );
 
-        self.stride += Group::WIDTH;
-        self.pos += self.stride;
-        self.pos &= bucket_mask;
+        self.stride = self.stride.wrapping_add(Group::WIDTH);
+        self.pos = self.pos.wrapping_add(self.stride) & bucket_mask;
     }
 }
 


### PR DESCRIPTION
## Bug

In `ProbeSeq::move_next` (src/raw.rs), `stride` and `pos` are updated with plain `+=`:

```rust
self.stride += Group::WIDTH;
self.pos += self.stride;
self.pos &= bucket_mask;
```

In a debug build this panics; in a release build it produces undefined behavior (integer overflow). Although the existing `debug_assert!` verifies that `stride <= bucket_mask` before the addition, it fires *before* the increment, so the assert itself does not rule out overflow once `Group::WIDTH` is added.

This was identified via Kani formal verification and confirmed as a bug by @Amanieu in #735.

## Fix

Replace the plain additions with `wrapping_add`, which is what the subsequent `& bucket_mask` mask assumes:

```rust
self.stride = self.stride.wrapping_add(Group::WIDTH);
self.pos = self.pos.wrapping_add(self.stride) & bucket_mask;
```

The logic is otherwise identical; `wrapping_add` only differs from `+` when overflow would occur, and the final mask ensures `pos` stays in range regardless.

## Verification

`cargo check` passes cleanly. `cargo test` cannot run on this machine due to an absent MSVC linker, but the type-level correctness of the change is confirmed by `cargo check`.

Closes #735