### PR TITLE
Add debug assertion documenting the bucket_mask overflow invariant

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -185,6 +185,9 @@ fn bucket_mask_to_capacity(bucket_mask: usize) -> usize {
         // Keep in mind that the bucket mask is one less than the bucket count.
         bucket_mask
     } else {
+        // `bucket_mask` is bounded by the maximum allocation size, so it can
+        // never be `usize::MAX` and the `+ 1` below cannot overflow.
+        debug_assert!(bucket_mask != usize::MAX);
         // For larger tables we reserve 12.5% of the slots as empty.
         ((bucket_mask + 1) / 8) * 7
     }


### PR DESCRIPTION
Follows up #734. You said a debug assertion would be a good way to document that bucket_mask can never be usize::MAX, so this adds one where the +1 happens.

Fixes #734.