### PR TITLE
refactor: use `std::hash::RandomState`

### DIFF
--- a/benches/general_ops.rs
+++ b/benches/general_ops.rs
@@ -6,7 +6,7 @@ use criterion::Criterion;
 use hashbrown::DefaultHashBuilder;
 use hashbrown::{HashMap, HashSet};
 use std::{
-    collections::hash_map::RandomState,
+    hash::RandomState,
     hint::black_box,
     sync::atomic::{self, AtomicUsize},
 };

--- a/tests/hasher.rs
+++ b/tests/hasher.rs
@@ -29,7 +29,7 @@ fn default() {
 /// Use std's default hasher.
 #[test]
 fn random_state() {
-    check::<std::collections::hash_map::RandomState>();
+    check::<std::hash::RandomState>();
 }
 
 /// Use a constant 0 hash.


### PR DESCRIPTION
Since Rust 1.76 we can use `std::hash::RandomState` instead of `std::collections::hash_map::RandomState`.