### PR TITLE
style: refactor import layout

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+imports_layout = "Vertical"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,9 @@
 #![expect(missing_docs)] // criterion_group! generates a public bench entrypoint
 
-use criterion::{criterion_group, criterion_main};
+use criterion::{
+    criterion_group,
+    criterion_main,
+};
 
 mod general_ops;
 mod insert_unique_unchecked;

--- a/benches/general_ops.rs
+++ b/benches/general_ops.rs
@@ -2,13 +2,21 @@
 //! * Hasher: std default (SipHash) and crate default (foldhash).
 //! * Int key distribution: low bit heavy, top bit heavy, and random.
 //! * Task: basic functionality: insert, insert_erase, lookup, lookup_fail, iter
-use criterion::Criterion;
-use hashbrown::DefaultHashBuilder;
-use hashbrown::{HashMap, HashSet};
+
 use std::{
     hash::RandomState,
     hint::black_box,
-    sync::atomic::{self, AtomicUsize},
+    sync::atomic::{
+        self,
+        AtomicUsize,
+    },
+};
+
+use criterion::Criterion;
+use hashbrown::{
+    DefaultHashBuilder,
+    HashMap,
+    HashSet,
 };
 
 const SIZE: usize = 1000;

--- a/benches/insert_unique_unchecked.rs
+++ b/benches/insert_unique_unchecked.rs
@@ -1,7 +1,9 @@
 //! Compare `insert` and `insert_unique_unchecked` operations performance.
+
+use std::hint::black_box;
+
 use criterion::Criterion;
 use hashbrown::HashMap;
-use std::hint::black_box;
 
 pub(crate) fn register_benches(c: &mut Criterion) {
     let keys: Vec<String> = (0..1000).map(|i| format!("xxxx{i}yyyy")).collect();

--- a/benches/set_ops.rs
+++ b/benches/set_ops.rs
@@ -4,6 +4,7 @@
 //!
 //! Each assigning test is done in the configuration that is faster. Cheating, I know.
 //! The exception to this is Sub, because there the result differs. So I made two benchmarks for Sub.
+
 use criterion::Criterion;
 use hashbrown::HashSet;
 

--- a/benches/with_capacity.rs
+++ b/benches/with_capacity.rs
@@ -1,6 +1,7 @@
+use std::hint::black_box;
+
 use criterion::Criterion;
 use hashbrown::HashMap;
-use std::hint::black_box;
 
 type Map<K, V> = HashMap<K, V>;
 

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,6 +1,10 @@
 #[cfg(test)]
 pub(crate) use self::inner::AllocError;
-pub(crate) use self::inner::{Allocator, Global, do_alloc};
+pub(crate) use self::inner::{
+    Allocator,
+    Global,
+    do_alloc,
+};
 
 // Nightly-case.
 // Use unstable `allocator_api` feature.
@@ -8,11 +12,17 @@ pub(crate) use self::inner::{Allocator, Global, do_alloc};
 // This is used when building for `std`.
 #[cfg(feature = "nightly")]
 mod inner {
-    use core::alloc::Layout;
-    use core::ptr::NonNull;
+    use core::{
+        alloc::Layout,
+        ptr::NonNull,
+    };
+
     #[cfg(test)]
     pub(crate) use stdalloc::alloc::AllocError;
-    pub(crate) use stdalloc::alloc::{Allocator, Global};
+    pub(crate) use stdalloc::alloc::{
+        Allocator,
+        Global,
+    };
 
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<[u8]>, ()> {
         match alloc.allocate(layout) {
@@ -30,11 +40,17 @@ mod inner {
 // `core::alloc::Allocator`.
 #[cfg(all(not(feature = "nightly"), feature = "allocator-api2"))]
 mod inner {
+    use core::{
+        alloc::Layout,
+        ptr::NonNull,
+    };
+
     #[cfg(test)]
     pub(crate) use allocator_api2::alloc::AllocError;
-    pub(crate) use allocator_api2::alloc::{Allocator, Global};
-    use core::alloc::Layout;
-    use core::ptr::NonNull;
+    pub(crate) use allocator_api2::alloc::{
+        Allocator,
+        Global,
+    };
 
     pub(crate) fn do_alloc<A: Allocator>(alloc: &A, layout: Layout) -> Result<NonNull<[u8]>, ()> {
         match alloc.allocate(layout) {
@@ -54,9 +70,15 @@ mod inner {
 // or `nightly` without disturbing users that don't want to use it.
 #[cfg(not(any(feature = "nightly", feature = "allocator-api2")))]
 mod inner {
-    use core::alloc::Layout;
-    use core::ptr::NonNull;
-    use stdalloc::alloc::{alloc, dealloc};
+    use core::{
+        alloc::Layout,
+        ptr::NonNull,
+    };
+
+    use stdalloc::alloc::{
+        alloc,
+        dealloc,
+    };
 
     #[expect(clippy::missing_safety_doc)] // not exposed outside of this crate
     pub unsafe trait Allocator {

--- a/src/control/bitmask.rs
+++ b/src/control/bitmask.rs
@@ -1,4 +1,9 @@
-use super::group::{BITMASK_ITER_MASK, BITMASK_STRIDE, BitMaskWord, NonZeroBitMaskWord};
+use super::group::{
+    BITMASK_ITER_MASK,
+    BITMASK_STRIDE,
+    BitMaskWord,
+    NonZeroBitMaskWord,
+};
 
 /// A bit mask which contains the result of a `Match` operation on a `Group` and
 /// allows iterating through them.

--- a/src/control/group/generic.rs
+++ b/src/control/group/generic.rs
@@ -1,5 +1,9 @@
-use super::super::{BitMask, Tag};
 use core::ptr;
+
+use super::super::{
+    BitMask,
+    Tag,
+};
 
 // Use the native word size as the group size. Using a 64-bit group size on
 // a 32-bit architecture will just end up being more expensive because

--- a/src/control/group/lsx.rs
+++ b/src/control/group/lsx.rs
@@ -1,7 +1,12 @@
-use super::super::{BitMask, Tag};
-use core::num::NonZeroU16;
+use core::{
+    arch::loongarch64::*,
+    num::NonZeroU16,
+};
 
-use core::arch::loongarch64::*;
+use super::super::{
+    BitMask,
+    Tag,
+};
 
 pub(crate) type BitMaskWord = u16;
 pub(crate) type NonZeroBitMaskWord = NonZeroU16;

--- a/src/control/group/mod.rs
+++ b/src/control/group/mod.rs
@@ -49,4 +49,9 @@ cfg_select! {
     }
 }
 pub(crate) use self::imp::Group;
-pub(super) use self::imp::{BITMASK_ITER_MASK, BITMASK_STRIDE, BitMaskWord, NonZeroBitMaskWord};
+pub(super) use self::imp::{
+    BITMASK_ITER_MASK,
+    BITMASK_STRIDE,
+    BitMaskWord,
+    NonZeroBitMaskWord,
+};

--- a/src/control/group/neon.rs
+++ b/src/control/group/neon.rs
@@ -1,6 +1,12 @@
-use super::super::{BitMask, Tag};
-use core::arch::aarch64 as neon;
-use core::num::NonZeroU64;
+use core::{
+    arch::aarch64 as neon,
+    num::NonZeroU64,
+};
+
+use super::super::{
+    BitMask,
+    Tag,
+};
 
 pub(crate) type BitMaskWord = u64;
 pub(crate) type NonZeroBitMaskWord = NonZeroU64;

--- a/src/control/group/sse2.rs
+++ b/src/control/group/sse2.rs
@@ -1,10 +1,13 @@
-use super::super::{BitMask, Tag};
-use core::num::NonZeroU16;
-
 #[cfg(target_arch = "x86")]
 use core::arch::x86;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64 as x86;
+use core::num::NonZeroU16;
+
+use super::super::{
+    BitMask,
+    Tag,
+};
 
 pub(crate) type BitMaskWord = u16;
 pub(crate) type NonZeroBitMaskWord = NonZeroU16;

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -6,5 +6,8 @@ use self::bitmask::BitMask;
 pub(crate) use self::{
     bitmask::BitMaskIter,
     group::Group,
-    tag::{Tag, TagSliceExt},
+    tag::{
+        Tag,
+        TagSliceExt,
+    },
 };

--- a/src/control/tag.rs
+++ b/src/control/tag.rs
@@ -1,4 +1,7 @@
-use core::{fmt, mem};
+use core::{
+    fmt,
+    mem,
+};
 
 /// Single tag in a control group.
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/src/external_trait_impls/rayon/helpers.rs
+++ b/src/external_trait_impls/rayon/helpers.rs
@@ -1,7 +1,10 @@
 use stdalloc::collections::LinkedList;
 use stdalloc::vec::Vec;
 
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::iter::{
+    IntoParallelIterator,
+    ParallelIterator,
+};
 
 /// Helper for collecting parallel iterators to an intermediary
 #[expect(clippy::linkedlist)] // yes, we need linked list here for efficient appending!

--- a/src/external_trait_impls/rayon/map.rs
+++ b/src/external_trait_impls/rayon/map.rs
@@ -1,13 +1,35 @@
 //! Rayon extensions for `HashMap`.
 
-use super::raw::{RawIntoParIter, RawParDrain, RawParIter};
-use crate::HashMap;
-use crate::alloc::{Allocator, Global};
-use core::fmt;
-use core::hash::{BuildHasher, Hash};
-use core::marker::PhantomData;
-use rayon::iter::plumbing::UnindexedConsumer;
-use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
+use core::{
+    fmt,
+    hash::{
+        BuildHasher,
+        Hash,
+    },
+    marker::PhantomData,
+};
+
+use rayon::iter::{
+    FromParallelIterator,
+    IntoParallelIterator,
+    ParallelExtend,
+    ParallelIterator,
+    plumbing::UnindexedConsumer,
+};
+
+use crate::{
+    HashMap,
+    alloc::{
+        Allocator,
+        Global,
+    },
+};
+
+use super::raw::{
+    RawIntoParIter,
+    RawParDrain,
+    RawParIter,
+};
 
 /// Parallel iterator over shared references to entries in a map.
 ///
@@ -456,11 +478,19 @@ where
 
 #[cfg(test)]
 mod test_par_map {
-    use core::hash::{Hash, Hasher};
-    use core::sync::atomic::{AtomicUsize, Ordering};
-    use stdalloc::vec::Vec;
+    use core::{
+        hash::{
+            Hash,
+            Hasher,
+        },
+        sync::atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+    };
 
     use rayon::prelude::*;
+    use stdalloc::vec::Vec;
 
     use crate::HashMap;
 

--- a/src/external_trait_impls/rayon/raw.rs
+++ b/src/external_trait_impls/rayon/raw.rs
@@ -1,12 +1,31 @@
-use crate::alloc::{Allocator, Global};
-use crate::raw::{Bucket, RawIter, RawIterRange, RawTable};
-use crate::scopeguard::guard;
-use core::marker::PhantomData;
-use core::mem;
-use core::ptr::NonNull;
+use core::{
+    marker::PhantomData,
+    mem,
+    ptr::NonNull,
+};
+
 use rayon::iter::{
     ParallelIterator,
-    plumbing::{self, Folder, UnindexedConsumer, UnindexedProducer},
+    plumbing::{
+        self,
+        Folder,
+        UnindexedConsumer,
+        UnindexedProducer,
+    },
+};
+
+use crate::{
+    alloc::{
+        Allocator,
+        Global,
+    },
+    raw::{
+        Bucket,
+        RawIter,
+        RawIterRange,
+        RawTable,
+    },
+    scopeguard::guard,
 };
 
 /// Parallel iterator which returns a raw pointer to every full bucket in the table.

--- a/src/external_trait_impls/rayon/set.rs
+++ b/src/external_trait_impls/rayon/set.rs
@@ -1,11 +1,27 @@
 //! Rayon extensions for `HashSet`.
 
+use core::hash::{
+    BuildHasher,
+    Hash,
+};
+
+use rayon::iter::{
+    FromParallelIterator,
+    IntoParallelIterator,
+    ParallelExtend,
+    ParallelIterator,
+    plumbing::UnindexedConsumer,
+};
+
+use crate::{
+    HashSet,
+    alloc::{
+        Allocator,
+        Global,
+    },
+};
+
 use super::map;
-use crate::HashSet;
-use crate::alloc::{Allocator, Global};
-use core::hash::{BuildHasher, Hash};
-use rayon::iter::plumbing::UnindexedConsumer;
-use rayon::iter::{FromParallelIterator, IntoParallelIterator, ParallelExtend, ParallelIterator};
 
 /// Parallel iterator over elements of a consumed set.
 ///
@@ -386,10 +402,13 @@ where
 
 #[cfg(test)]
 mod test_par_set {
-    use core::sync::atomic::{AtomicUsize, Ordering};
-    use stdalloc::vec::Vec;
+    use core::sync::atomic::{
+        AtomicUsize,
+        Ordering,
+    };
 
     use rayon::prelude::*;
+    use stdalloc::vec::Vec;
 
     use crate::HashSet;
 

--- a/src/external_trait_impls/rayon/table.rs
+++ b/src/external_trait_impls/rayon/table.rs
@@ -1,12 +1,29 @@
 //! Rayon extensions for `HashTable`.
 
-use super::raw::{RawIntoParIter, RawParDrain, RawParIter};
-use crate::HashTable;
-use crate::alloc::{Allocator, Global};
-use core::fmt;
-use core::marker::PhantomData;
-use rayon::iter::plumbing::UnindexedConsumer;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use core::{
+    fmt,
+    marker::PhantomData,
+};
+
+use rayon::iter::{
+    IntoParallelIterator,
+    ParallelIterator,
+    plumbing::UnindexedConsumer,
+};
+
+use crate::{
+    HashTable,
+    alloc::{
+        Allocator,
+        Global,
+    },
+};
+
+use super::raw::{
+    RawIntoParIter,
+    RawParDrain,
+    RawParIter,
+};
 
 /// Parallel iterator over shared references to entries in a map.
 ///
@@ -206,12 +223,19 @@ impl<'a, T: Send, A: Allocator> IntoParallelIterator for &'a mut HashTable<T, A>
 
 #[cfg(test)]
 mod test_par_table {
-    use core::sync::atomic::{AtomicUsize, Ordering};
-    use stdalloc::vec::Vec;
+    use core::sync::atomic::{
+        AtomicUsize,
+        Ordering,
+    };
 
     use rayon::prelude::*;
+    use stdalloc::vec::Vec;
 
-    use crate::{DefaultHashBuilder, hash_map::make_hash, hash_table::HashTable};
+    use crate::{
+        DefaultHashBuilder,
+        hash_map::make_hash,
+        hash_table::HashTable,
+    };
 
     #[test]
     fn test_iterate() {

--- a/src/external_trait_impls/serde.rs
+++ b/src/external_trait_impls/serde.rs
@@ -11,14 +11,32 @@ mod size_hint {
 }
 
 mod map {
-    use crate::alloc::Allocator;
-    use core::fmt;
-    use core::hash::{BuildHasher, Hash};
-    use core::marker::PhantomData;
-    use serde_core::de::{Deserialize, Deserializer, MapAccess, Visitor};
-    use serde_core::ser::{Serialize, Serializer};
+    use core::{
+        fmt,
+        hash::{
+            BuildHasher,
+            Hash,
+        },
+        marker::PhantomData,
+    };
 
-    use crate::HashMap;
+    use serde_core::{
+        de::{
+            Deserialize,
+            Deserializer,
+            MapAccess,
+            Visitor,
+        },
+        ser::{
+            Serialize,
+            Serializer,
+        },
+    };
+
+    use crate::{
+        HashMap,
+        alloc::Allocator,
+    };
 
     use super::size_hint;
 
@@ -97,14 +115,32 @@ mod map {
 }
 
 mod set {
-    use crate::alloc::Allocator;
-    use core::fmt;
-    use core::hash::{BuildHasher, Hash};
-    use core::marker::PhantomData;
-    use serde_core::de::{Deserialize, Deserializer, SeqAccess, Visitor};
-    use serde_core::ser::{Serialize, Serializer};
+    use core::{
+        fmt,
+        hash::{
+            BuildHasher,
+            Hash,
+        },
+        marker::PhantomData,
+    };
 
-    use crate::HashSet;
+    use serde_core::{
+        de::{
+            Deserialize,
+            Deserializer,
+            SeqAccess,
+            Visitor,
+        },
+        ser::{
+            Serialize,
+            Serializer,
+        },
+    };
+
+    use crate::{
+        HashSet,
+        alloc::Allocator,
+    };
 
     use super::size_hint;
 

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "default-hasher")]
 use {
-    core::hash::{BuildHasher, Hasher},
+    core::hash::{
+        BuildHasher,
+        Hasher,
+    },
     foldhash::fast::RandomState,
 };
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,17 +1,40 @@
-use crate::alloc::{Allocator, Global};
-use crate::raw::{Bucket, RawDrain, RawExtractIf, RawIntoIter, RawIter, RawTable};
-use crate::{DefaultHashBuilder, Equivalent, TryReserveError};
-use core::borrow::Borrow;
-use core::fmt::{self, Debug};
-use core::hash::{BuildHasher, Hash};
-use core::iter::FusedIterator;
-use core::marker::PhantomData;
-use core::mem;
-use core::ops::Index;
+use core::{
+    borrow::Borrow,
+    fmt::{
+        self,
+        Debug,
+    },
+    hash::{
+        BuildHasher,
+        Hash,
+    },
+    iter::FusedIterator,
+    marker::PhantomData,
+    mem,
+    ops::Index,
+};
+
 use stdalloc::borrow::ToOwned;
 
 #[cfg(feature = "raw-entry")]
 pub use crate::raw_entry::*;
+use crate::{
+    DefaultHashBuilder,
+    Equivalent,
+    TryReserveError,
+    alloc::{
+        Allocator,
+        Global,
+    },
+    raw::{
+        Bucket,
+        RawDrain,
+        RawExtractIf,
+        RawIntoIter,
+        RawIter,
+        RawTable,
+    },
+};
 
 /// A hash map implemented with quadratic probing and SIMD lookup.
 ///
@@ -5078,20 +5101,45 @@ fn assert_covariance() {
 
 #[cfg(test)]
 mod test_map {
-    use super::DefaultHashBuilder;
-    use super::Entry::{Occupied, Vacant};
-    use super::EntryRef;
-    use super::HashMap;
-    use crate::alloc::{AllocError, Allocator, Global};
-    use core::alloc::Layout;
-    use core::ptr::NonNull;
-    use core::sync::atomic::{AtomicI8, Ordering};
-    use rand::{Rng, SeedableRng, rngs::SmallRng};
-    use std::borrow::ToOwned;
-    use std::cell::RefCell;
-    use std::vec::Vec;
-    use stdalloc::string::String;
-    use stdalloc::sync::Arc;
+    use core::{
+        alloc::Layout,
+        ptr::NonNull,
+        sync::atomic::{
+            AtomicI8,
+            Ordering,
+        },
+    };
+    use std::{
+        borrow::ToOwned,
+        cell::RefCell,
+        vec::Vec,
+    };
+
+    use rand::{
+        Rng,
+        SeedableRng,
+        rngs::SmallRng,
+    };
+    use stdalloc::{
+        string::String,
+        sync::Arc,
+    };
+
+    use crate::alloc::{
+        AllocError,
+        Allocator,
+        Global,
+    };
+
+    use super::{
+        DefaultHashBuilder,
+        Entry::{
+            Occupied,
+            Vacant,
+        },
+        EntryRef,
+        HashMap,
+    };
 
     #[test]
     fn test_zero_capacities() {
@@ -6044,6 +6092,7 @@ mod test_map {
     #[test]
     fn test_extend_ref_kv_tuple() {
         use std::ops::AddAssign;
+
         let mut a = HashMap::new();
         a.insert(0, 0);
 
@@ -6322,7 +6371,10 @@ mod test_map {
     #[test]
     #[cfg_attr(miri, ignore)] // FIXME: no OOM signalling (https://github.com/rust-lang/miri/issues/613)
     fn test_try_reserve() {
-        use crate::TryReserveError::{AllocError, CapacityOverflow};
+        use crate::TryReserveError::{
+            AllocError,
+            CapacityOverflow,
+        };
 
         const MAX_ISIZE: usize = isize::MAX as usize;
 
@@ -6902,16 +6954,28 @@ mod test_map {
 
 #[cfg(all(test, unix, any(feature = "nightly", feature = "allocator-api2")))]
 mod test_map_with_mmap_allocations {
-    use super::HashMap;
-    use crate::raw::prev_pow2;
-    use core::alloc::Layout;
-    use core::ptr::{NonNull, null_mut};
-
     #[cfg(feature = "nightly")]
-    use core::alloc::{AllocError, Allocator};
+    use core::alloc::{
+        AllocError,
+        Allocator,
+    };
+    use core::{
+        alloc::Layout,
+        ptr::{
+            NonNull,
+            null_mut,
+        },
+    };
 
     #[cfg(all(feature = "allocator-api2", not(feature = "nightly")))]
-    use allocator_api2::alloc::{AllocError, Allocator};
+    use allocator_api2::alloc::{
+        AllocError,
+        Allocator,
+    };
+
+    use crate::raw::prev_pow2;
+
+    use super::HashMap;
 
     /// This is not a production quality allocator, just good enough for
     /// some basic tests.

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,20 +1,42 @@
-use crate::TryReserveError;
-use crate::control::{BitMaskIter, Group, Tag, TagSliceExt};
-use crate::scopeguard::{ScopeGuard, guard};
-use crate::util::{likely, unlikely};
-use core::alloc::Layout;
-use core::array;
-use core::iter::FusedIterator;
-use core::marker::PhantomData;
-use core::mem;
-use core::ptr;
-use core::ptr::NonNull;
-use core::slice;
+use core::{
+    alloc::Layout,
+    array,
+    iter::FusedIterator,
+    marker::PhantomData,
+    mem,
+    ptr::{
+        self,
+        NonNull,
+    },
+    slice,
+};
+
 use stdalloc::alloc::handle_alloc_error;
 
 #[cfg(test)]
 use crate::alloc::AllocError;
-use crate::alloc::{Allocator, Global, do_alloc};
+use crate::{
+    TryReserveError,
+    alloc::{
+        Allocator,
+        Global,
+        do_alloc,
+    },
+    control::{
+        BitMaskIter,
+        Group,
+        Tag,
+        TagSliceExt,
+    },
+    scopeguard::{
+        ScopeGuard,
+        guard,
+    },
+    util::{
+        likely,
+        unlikely,
+    },
+};
 
 #[inline]
 unsafe fn offset_from<T>(to: *const T, from: *const T) -> usize {
@@ -4487,11 +4509,22 @@ mod test_map {
     #[test]
     #[cfg(panic = "unwind")]
     fn test_catch_panic_clone_from() {
-        use super::{AllocError, Allocator, Global};
-        use core::sync::atomic::{AtomicI8, Ordering};
+        use core::sync::atomic::{
+            AtomicI8,
+            Ordering,
+        };
         use std::thread;
-        use stdalloc::sync::Arc;
-        use stdalloc::vec::Vec;
+
+        use stdalloc::{
+            sync::Arc,
+            vec::Vec,
+        };
+
+        use super::{
+            AllocError,
+            Allocator,
+            Global,
+        };
 
         struct MyAllocInner {
             drop_count: Arc<AtomicI8>,

--- a/src/raw_entry.rs
+++ b/src/raw_entry.rs
@@ -1,10 +1,32 @@
-use crate::Equivalent;
-use crate::alloc::{Allocator, Global};
-use crate::map::{HashMap, equivalent, make_hash, make_hasher};
-use crate::raw::{Bucket, RawTable};
-use core::fmt::{self, Debug};
-use core::hash::{BuildHasher, Hash};
-use core::mem;
+use core::{
+    fmt::{
+        self,
+        Debug,
+    },
+    hash::{
+        BuildHasher,
+        Hash,
+    },
+    mem,
+};
+
+use crate::{
+    Equivalent,
+    alloc::{
+        Allocator,
+        Global,
+    },
+    map::{
+        HashMap,
+        equivalent,
+        make_hash,
+        make_hasher,
+    },
+    raw::{
+        Bucket,
+        RawTable,
+    },
+};
 
 impl<K, V, S, A: Allocator> HashMap<K, V, S, A> {
     /// Creates a raw entry builder for the `HashMap`.
@@ -1583,7 +1605,10 @@ mod test_map {
 
     #[test]
     fn test_raw_entry() {
-        use super::RawEntryMut::{Occupied, Vacant};
+        use super::RawEntryMut::{
+            Occupied,
+            Vacant,
+        };
 
         let xs = [(1_i32, 10_i32), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)];
 

--- a/src/rustc_entry.rs
+++ b/src/rustc_entry.rs
@@ -1,10 +1,36 @@
+use core::{
+    fmt::{
+        self,
+        Debug,
+    },
+    hash::{
+        BuildHasher,
+        Hash,
+    },
+    mem,
+};
+
+use crate::{
+    alloc::{
+        Allocator,
+        Global,
+    },
+    map::{
+        Drain,
+        HashMap,
+        IntoIter,
+        Iter,
+        IterMut,
+        make_hash,
+        make_hasher,
+    },
+    raw::{
+        Bucket,
+        RawTable,
+    },
+};
+
 use self::RustcEntry::*;
-use crate::alloc::{Allocator, Global};
-use crate::map::{Drain, HashMap, IntoIter, Iter, IterMut, make_hash, make_hasher};
-use crate::raw::{Bucket, RawTable};
-use core::fmt::{self, Debug};
-use core::hash::{BuildHasher, Hash};
-use core::mem;
 
 impl<K, V, S, A> HashMap<K, V, S, A>
 where

--- a/src/scopeguard.rs
+++ b/src/scopeguard.rs
@@ -1,7 +1,10 @@
 // Extracted from the scopeguard crate
 use core::{
     mem::ManuallyDrop,
-    ops::{Deref, DerefMut},
+    ops::{
+        Deref,
+        DerefMut,
+    },
     ptr,
 };
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,14 +1,42 @@
-use crate::{Equivalent, TryReserveError};
-use core::cell::UnsafeCell;
-use core::fmt;
-use core::hash::{BuildHasher, Hash};
-use core::iter::{Chain, FusedIterator};
-use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    hash::{
+        BuildHasher,
+        Hash,
+    },
+    iter::{
+        Chain,
+        FusedIterator,
+    },
+    ops::{
+        BitAnd,
+        BitAndAssign,
+        BitOr,
+        BitOrAssign,
+        BitXor,
+        BitXorAssign,
+        Sub,
+        SubAssign,
+    },
+};
 
-use super::map::{self, HashMap, Keys};
-use crate::DefaultHashBuilder;
-use crate::alloc::{Allocator, Global};
-use crate::raw::RawExtractIf;
+use crate::{
+    DefaultHashBuilder,
+    Equivalent,
+    TryReserveError,
+    alloc::{
+        Allocator,
+        Global,
+    },
+    raw::RawExtractIf,
+};
+
+use super::map::{
+    self,
+    HashMap,
+    Keys,
+};
 
 // Future Optimization (FIXME!)
 // =============================
@@ -2545,10 +2573,17 @@ fn assert_covariance() {
 
 #[cfg(test)]
 mod test_set {
-    use super::{Equivalent, HashSet};
-    use crate::DefaultHashBuilder;
-    use crate::map::make_hash;
     use std::vec::Vec;
+
+    use crate::{
+        DefaultHashBuilder,
+        map::make_hash,
+    };
+
+    use super::{
+        Equivalent,
+        HashSet,
+    };
 
     #[test]
     fn test_zero_capacities() {
@@ -3046,7 +3081,11 @@ mod test_set {
     #[test]
     #[should_panic]
     fn some_invalid_equivalent() {
-        use core::hash::{Hash, Hasher};
+        use core::hash::{
+            Hash,
+            Hasher,
+        };
+
         struct Invalid {
             count: u32,
             other: u32,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,12 +1,27 @@
-use core::{fmt, iter::FusedIterator, marker::PhantomData, ptr::NonNull};
+use core::{
+    fmt,
+    iter::FusedIterator,
+    marker::PhantomData,
+    ptr::NonNull,
+};
 
 use crate::{
     TryReserveError,
-    alloc::{Allocator, Global},
+    alloc::{
+        Allocator,
+        Global,
+    },
     control::Tag,
     raw::{
-        Bucket, FullBucketsIndices, RawDrain, RawExtractIf, RawIntoIter, RawIter, RawIterHash,
-        RawIterHashIndices, RawTable,
+        Bucket,
+        FullBucketsIndices,
+        RawDrain,
+        RawExtractIf,
+        RawIntoIter,
+        RawIter,
+        RawIterHash,
+        RawIterHashIndices,
+        RawTable,
     },
 };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,9 @@
 // FIXME: Replace with `core::hint::{likely, unlikely}` once they are stable.
 #[cfg(feature = "nightly")]
-pub(crate) use core::intrinsics::{likely, unlikely};
+pub(crate) use core::intrinsics::{
+    likely,
+    unlikely,
+};
 
 #[cfg(not(feature = "nightly"))]
 #[inline(always)]

--- a/tests/equivalent_trait.rs
+++ b/tests/equivalent_trait.rs
@@ -1,9 +1,11 @@
 #![expect(missing_docs)] // https://github.com/rust-lang/rust/issues/137561
 
-use hashbrown::Equivalent;
-use hashbrown::HashMap;
-
 use std::hash::Hash;
+
+use hashbrown::{
+    Equivalent,
+    HashMap,
+};
 
 #[derive(Debug, Hash)]
 pub struct Pair<A, B>(pub A, pub B);

--- a/tests/hasher.rs
+++ b/tests/hasher.rs
@@ -2,8 +2,13 @@
 
 #![cfg(not(miri))] // FIXME: takes too long
 
+use std::hash::{
+    BuildHasher,
+    BuildHasherDefault,
+    Hasher,
+};
+
 use hashbrown::HashSet;
-use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
 
 fn check<S: BuildHasher + Default>() {
     let range = 0..1_000;

--- a/tests/hasher_unwind.rs
+++ b/tests/hasher_unwind.rs
@@ -9,14 +9,27 @@
 //! lookups can no longer find the original keys and iteration starts yielding
 //! repeated garbage-like entries.
 
-use hashbrown::HashMap;
-use std::collections::BTreeSet;
 use std::{
-    hash::{BuildHasher, Hash, Hasher},
-    panic::{AssertUnwindSafe, catch_unwind},
-    sync::Mutex,
-    sync::atomic::{AtomicUsize, Ordering},
+    collections::BTreeSet,
+    hash::{
+        BuildHasher,
+        Hash,
+        Hasher,
+    },
+    panic::{
+        AssertUnwindSafe,
+        catch_unwind,
+    },
+    sync::{
+        Mutex,
+        atomic::{
+            AtomicUsize,
+            Ordering,
+        },
+    },
 };
+
+use hashbrown::HashMap;
 
 /// One-shot panic switch used to trigger the first `build_hasher` call that
 /// occurs inside `reserve(1)`.

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,12 +1,19 @@
 #![expect(missing_docs)] // https://github.com/rust-lang/rust/issues/137561
 #![cfg(feature = "rayon")]
 
-use hashbrown::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use hashbrown::{
+    HashMap,
+    HashSet,
+};
 use rayon::iter::{
-    IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelExtend,
+    IntoParallelIterator,
+    IntoParallelRefIterator,
+    IntoParallelRefMutIterator,
+    ParallelExtend,
     ParallelIterator,
 };
-use std::sync::LazyLock;
 
 macro_rules! assert_eq3 {
     ($e1:expr, $e2:expr, $e3:expr) => {{

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,9 +2,16 @@
 #![cfg(feature = "serde")]
 
 use core::hash::BuildHasherDefault;
+
 use fnv::FnvHasher;
-use hashbrown::{HashMap, HashSet};
-use serde_test::{Token, assert_tokens};
+use hashbrown::{
+    HashMap,
+    HashSet,
+};
+use serde_test::{
+    Token,
+    assert_tokens,
+};
 
 // We use FnvHash for this test because we rely on the ordering
 type FnvHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FnvHasher>>;

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -1,9 +1,15 @@
 #![expect(missing_docs)] // https://github.com/rust-lang/rust/issues/137561
 #![cfg(not(miri))] // FIXME: takes too long
 
-use hashbrown::HashSet;
-use rand::{Rng, SeedableRng, distr::Alphanumeric, rngs::SmallRng};
 use std::iter;
+
+use hashbrown::HashSet;
+use rand::{
+    Rng,
+    SeedableRng,
+    distr::Alphanumeric,
+    rngs::SmallRng,
+};
 
 #[test]
 fn test_hashset_insert_remove() {


### PR DESCRIPTION
Configure `rustfmt` to use vertical import formatting and apply the new layout throughout the crate.

- Update` rustfmt` configuration and reformat imports throughout.
- Group related imports into multi-line use statements.

Use the following import order:

1. `core::`
1. `std::`
1. _external crates_
1. `crate::`
1. `super::`
1. `self::`